### PR TITLE
dropped conda install of mrtrix in dockerfile

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -113,6 +113,7 @@ jobs:
         cache-from: type=registry,ref=${{ steps.versions.outputs.IMAGE }}:buildcache
         cache-to: type=registry,ref=${{ steps.versions.outputs.IMAGE }}:buildcache,mode=max
         context: .
+        platforms: linux/amd64,linux/arm64
         push: ${{ github.event_name == 'release' }}
         tags: |
           ${{ steps.versions.outputs.TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,18 +5,8 @@ RUN apt-get update && apt-get install -y \
   python3-pip \
   wget \
   git \
+  mrtrix3 \
   && rm -rf /var/lib/apt/lists/*
-
-# Install Miniconda
-RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
-  bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && \
-  rm Miniconda3-latest-Linux-x86_64.sh
-
-# Add Miniconda to PATH
-ENV PATH="/opt/conda/bin:${PATH}"
-
-# Install MRtrix3
-RUN  conda install -c mrtrix3 mrtrix3
 
 # Add application code
 ADD . /app


### PR DESCRIPTION
Fall back to system version of MRtrix3 due to issues with conda install across platforms