### PR TITLE
Bugfix for scan type names with special characters

### DIFF
--- a/xnat_ingest/cli/stage.py
+++ b/xnat_ingest/cli/stage.py
@@ -160,7 +160,7 @@ def stage(
     raise_errors: bool,
     deidentify: bool,
 ):
-    set_logger_handling(log_level, log_file, log_emails, mail_server)
+    set_logger_handling(log_level, log_emails, log_file, mail_server)
 
     msg = f"Loading DICOM sessions from '{dicoms_path}'"
 

--- a/xnat_ingest/cli/stage.py
+++ b/xnat_ingest/cli/stage.py
@@ -60,23 +60,23 @@ are uploaded to XNAT
 )
 @click.option(
     "--associated-files",
-    type=AssociatedFiles(),
+    type=AssociatedFiles,
     nargs=2,
     default=None,
     envvar="XNAT_INGEST_ASSOCIATED",
     metavar="<glob> <id-pattern>",
     help=(
-        "The \"glob\" arg is a glob pattern by which to detect associated files to be "
+        'The "glob" arg is a glob pattern by which to detect associated files to be '
         "attached to the DICOM sessions. Note that when this pattern corresponds to a "
         "relative path it is considered to be relative to the parent directory containing "
         "the DICOMs for the session NOT the current working directory Can contain string "
         "templates corresponding to DICOM metadata fields, which are substituted before "
         "the glob is called. For example, "
-        '"./associated/{PatientName.given_name}_{PatientName.family_name}/*)\" '
+        '"./associated/{PatientName.given_name}_{PatientName.family_name}/*)" '
         "will find all files under the subdirectory within '/path/to/dicoms/associated' that matches "
         "<GIVEN-NAME>_<FAMILY-NAME>. Will be interpreted as being relative to `dicoms_dir` "
         "if a relative path is provided.\n"
-        "The \"id-pattern\" arg is a regular expression that is used to extract the scan ID & "
+        'The "id-pattern" arg is a regular expression that is used to extract the scan ID & '
         "type/resource from the associated filename. Should be a regular-expression "
         "(Python syntax) with named groups called 'id' and 'type', e.g. "
         r"--assoc-id-pattern '[^\.]+\.[^\.]+\.(?P<id>\d+)\.(?P<type>\w+)\..*'"
@@ -98,7 +98,7 @@ are uploaded to XNAT
 @click.option(
     "--log-file",
     default=None,
-    type=LogFile(),
+    type=LogFile,
     nargs=2,
     metavar="<path> <loglevel>",
     envvar="XNAT_INGEST_LOGFILE",
@@ -110,7 +110,7 @@ are uploaded to XNAT
 @click.option(
     "--log-email",
     "log_emails",
-    type=LogEmail(),
+    type=LogEmail,
     nargs=3,
     metavar="<address> <loglevel> <subject-preamble>",
     multiple=True,
@@ -122,7 +122,7 @@ are uploaded to XNAT
 )
 @click.option(
     "--mail-server",
-    type=MailServer(),
+    type=MailServer,
     nargs=4,
     metavar="<host> <sender-email> <user> <password>",
     default=None,
@@ -142,7 +142,7 @@ are uploaded to XNAT
     "--deidentify/--dont-deidentify",
     default=False,
     type=bool,
-    help="whether to deidentify the file names and DICOM metadata before staging"
+    help="whether to deidentify the file names and DICOM metadata before staging",
 )
 def stage(
     dicoms_path: str,
@@ -193,7 +193,8 @@ def stage(
                 continue
             # Identify theDeidentify files if necessary and save them to the staging directory
             session.stage(
-                staging_dir, associated_files=associated_files,
+                staging_dir,
+                associated_files=associated_files,
                 remove_original=delete,
                 deidentify=deidentify,
             )

--- a/xnat_ingest/cli/stage.py
+++ b/xnat_ingest/cli/stage.py
@@ -60,7 +60,7 @@ are uploaded to XNAT
 )
 @click.option(
     "--associated-files",
-    type=AssociatedFiles,
+    type=AssociatedFiles.cli_type,
     nargs=2,
     default=None,
     envvar="XNAT_INGEST_ASSOCIATED",
@@ -98,7 +98,7 @@ are uploaded to XNAT
 @click.option(
     "--log-file",
     default=None,
-    type=LogFile,
+    type=LogFile.cli_type,
     nargs=2,
     metavar="<path> <loglevel>",
     envvar="XNAT_INGEST_LOGFILE",
@@ -110,7 +110,7 @@ are uploaded to XNAT
 @click.option(
     "--log-email",
     "log_emails",
-    type=LogEmail,
+    type=LogEmail.cli_type,
     nargs=3,
     metavar="<address> <loglevel> <subject-preamble>",
     multiple=True,
@@ -122,7 +122,7 @@ are uploaded to XNAT
 )
 @click.option(
     "--mail-server",
-    type=MailServer,
+    type=MailServer.cli_type,
     nargs=4,
     metavar="<host> <sender-email> <user> <password>",
     default=None,

--- a/xnat_ingest/cli/transfer.py
+++ b/xnat_ingest/cli/transfer.py
@@ -99,7 +99,7 @@ an SSH server.
 @click.option(
     "--log-file",
     default=None,
-    type=LogFile,
+    type=LogFile.cli_type,
     nargs=2,
     metavar="<path> <loglevel>",
     envvar="XNAT_INGEST_LOGFILE",
@@ -111,7 +111,7 @@ an SSH server.
 @click.option(
     "--log-email",
     "log_emails",
-    type=LogEmail,
+    type=LogEmail.cli_type,
     nargs=3,
     metavar="<address> <loglevel> <subject-preamble>",
     multiple=True,
@@ -123,7 +123,7 @@ an SSH server.
 )
 @click.option(
     "--mail-server",
-    type=MailServer,
+    type=MailServer.cli_type,
     metavar="<host> <sender-email> <user> <password>",
     default=None,
     envvar="XNAT_INGEST_MAILSERVER",

--- a/xnat_ingest/cli/transfer.py
+++ b/xnat_ingest/cli/transfer.py
@@ -82,7 +82,7 @@ an SSH server.
 @click.argument("remote_store", type=str, envvar="XNAT_INGEST_REMOTE_STORE")
 @click.option(
     "--store-credentials",
-    type=str,
+    type=click.Path(path_type=Path),
     metavar="<access-key> <secret-key>",
     envvar="XNAT_INGEST_STORE_CREDENTIALS",
     default=None,
@@ -99,7 +99,7 @@ an SSH server.
 @click.option(
     "--log-file",
     default=None,
-    type=LogFile(),
+    type=LogFile,
     nargs=2,
     metavar="<path> <loglevel>",
     envvar="XNAT_INGEST_LOGFILE",
@@ -111,7 +111,7 @@ an SSH server.
 @click.option(
     "--log-email",
     "log_emails",
-    type=LogEmail(),
+    type=LogEmail,
     nargs=3,
     metavar="<address> <loglevel> <subject-preamble>",
     multiple=True,
@@ -123,7 +123,7 @@ an SSH server.
 )
 @click.option(
     "--mail-server",
-    type=MailServer(),
+    type=MailServer,
     metavar="<host> <sender-email> <user> <password>",
     default=None,
     envvar="XNAT_INGEST_MAILSERVER",
@@ -161,20 +161,19 @@ an SSH server.
     help="The number of days to keep files in the remote store for",
 )
 def transfer(
-    staging_dir: str,
+    staging_dir: Path,
     remote_store: str,
     credentials: ty.Tuple[str, str],
-    log_file: ty.Tuple[str, str],
+    log_file: LogFile,
     log_level: str,
-    log_emails: ty.List[ty.Tuple[str, str, str]],
-    mail_server: ty.Tuple[str, str, str, str],
+    log_emails: ty.List[LogEmail],
+    mail_server: ty.Tuple[MailServer],
     delete: bool,
     raise_errors: bool,
     xnat_login: ty.Optional[ty.Tuple[str, str, str]],
     clean_up_older_than: int,
 ):
 
-    staging_dir = Path(staging_dir)
     if not staging_dir.exists():
         raise ValueError(f"Staging directory '{staging_dir}' does not exist")
 

--- a/xnat_ingest/cli/upload.py
+++ b/xnat_ingest/cli/upload.py
@@ -60,7 +60,7 @@ PASSWORD is the password for the XNAT user, alternatively "XNAT_INGEST_PASS" env
 @click.option(
     "--log-file",
     default=None,
-    type=LogFile(),
+    type=LogFile,
     nargs=2,
     metavar="<path> <loglevel>",
     envvar="XNAT_INGEST_LOGFILE",
@@ -72,7 +72,7 @@ PASSWORD is the password for the XNAT user, alternatively "XNAT_INGEST_PASS" env
 @click.option(
     "--log-email",
     "log_emails",
-    type=LogEmail(),
+    type=LogEmail,
     nargs=3,
     metavar="<address> <loglevel> <subject-preamble>",
     multiple=True,
@@ -84,7 +84,7 @@ PASSWORD is the password for the XNAT user, alternatively "XNAT_INGEST_PASS" env
 )
 @click.option(
     "--mail-server",
-    type=MailServer(),
+    type=MailServer,
     metavar="<host> <sender-email> <user> <password>",
     default=None,
     envvar="XNAT_INGEST_MAILSERVER",

--- a/xnat_ingest/cli/upload.py
+++ b/xnat_ingest/cli/upload.py
@@ -60,7 +60,7 @@ PASSWORD is the password for the XNAT user, alternatively "XNAT_INGEST_PASS" env
 @click.option(
     "--log-file",
     default=None,
-    type=LogFile,
+    type=LogFile.cli_type,
     nargs=2,
     metavar="<path> <loglevel>",
     envvar="XNAT_INGEST_LOGFILE",
@@ -72,7 +72,7 @@ PASSWORD is the password for the XNAT user, alternatively "XNAT_INGEST_PASS" env
 @click.option(
     "--log-email",
     "log_emails",
-    type=LogEmail,
+    type=LogEmail.cli_type,
     nargs=3,
     metavar="<address> <loglevel> <subject-preamble>",
     multiple=True,
@@ -84,7 +84,7 @@ PASSWORD is the password for the XNAT user, alternatively "XNAT_INGEST_PASS" env
 )
 @click.option(
     "--mail-server",
-    type=MailServer,
+    type=MailServer.cli_type,
     metavar="<host> <sender-email> <user> <password>",
     default=None,
     envvar="XNAT_INGEST_MAILSERVER",

--- a/xnat_ingest/utils.py
+++ b/xnat_ingest/utils.py
@@ -46,9 +46,9 @@ class MultiCliType(CliType):
 @attrs.define
 class LogEmail(CliType):
 
-    address: str = None
-    loglevel: str = None
-    subject: str = None
+    address: str
+    loglevel: str
+    subject: str
 
     def __str__(self):
         return self.address
@@ -64,7 +64,7 @@ def path_or_none_converter(path: str | Path | None):
 class LogFile(MultiCliType):
 
     path: Path = attrs.field(converter=path_or_none_converter, default=None)
-    loglevel: str = None
+    loglevel: ty.Optional[str] = None
 
     def __str__(self):
         return str(self.path)
@@ -76,27 +76,30 @@ class LogFile(MultiCliType):
 @attrs.define
 class MailServer(CliType):
 
-    host: str = None
-    sender_email: str = None
-    user: str = None
-    password: str = None
+    host: str
+    sender_email: str
+    user: str
+    password: str
 
 
 @attrs.define
 class AssociatedFiles(CliType):
 
-    glob: str = None
-    identity_pattern: str = None
+    glob: str
+    identity_pattern: str
 
 
 def set_logger_handling(
-    log_level: str, log_emails: ty.List[LogEmail] | None, log_file: LogFile | None, mail_server: MailServer
+    log_level: str,
+    log_emails: ty.List[LogEmail] | None,
+    log_file: LogFile | None,
+    mail_server: MailServer,
 ):
 
     levels = [log_level]
     if log_emails:
         levels.extend(le.loglevel for le in log_emails)
-    if log_file:
+    if log_file and log_file.loglevel:
         levels.append(log_file.loglevel)
 
     min_log_level = min(getattr(logging, ll.upper()) for ll in levels)
@@ -108,7 +111,7 @@ def set_logger_handling(
             raise ValueError(
                 "Mail server needs to be provided, either by `--mail-server` option or "
                 "XNAT_INGEST_MAILSERVER environment variable if logger emails "
-                "are provided: " + ", ".join(log_emails)
+                "are provided: " + ", ".join(str(le) for le in log_emails)
             )
         for log_email in log_emails:
             smtp_hdle = logging.handlers.SMTPHandler(
@@ -126,7 +129,8 @@ def set_logger_handling(
     if log_file:
         log_file.path.parent.mkdir(exist_ok=True)
         log_file_hdle = logging.FileHandler(log_file)
-        log_file_hdle.setLevel(getattr(logging, log_file.loglevel.upper()))
+        if log_file.loglevel:
+            log_file_hdle.setLevel(getattr(logging, log_file.loglevel.upper()))
         log_file_hdle.setFormatter(
             logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
         )
@@ -280,7 +284,7 @@ def transform_paths(
     while templ_attr_re.findall(expr):
         expr = templ_attr_re.sub(r"{\1.\2}", expr)
 
-    group_count = Counter()
+    group_count: Counter[str] = Counter()
 
     # Create regex groups for string template args
     def str_templ_to_regex_group(match) -> str:


### PR DESCRIPTION
* Escape scan type names so they are valid directory names and can be staged accordingly on the system