### PR TITLE
Add "run UID" to differentiate between staged directories that are created by different runs

### DIFF
--- a/xnat_ingest/cli/stage.py
+++ b/xnat_ingest/cli/stage.py
@@ -383,7 +383,7 @@ def stage(
                 else:
                     raise
 
-    if loop:
+    if loop is not None:
         while True:
             start_time = datetime.datetime.now()
             do_stage()

--- a/xnat_ingest/cli/upload.py
+++ b/xnat_ingest/cli/upload.py
@@ -416,7 +416,7 @@ def upload(
             else:
                 assert False
 
-    if loop:
+    if loop is not None:
         while True:
             start_time = datetime.datetime.now()
             do_upload()

--- a/xnat_ingest/store.py
+++ b/xnat_ingest/store.py
@@ -91,7 +91,7 @@ class ImagingSessionMockStore(Store):  # type: ignore[misc]
         id: str,
         leaves: ty.List[ty.Tuple[str, ...]],
         hierarchy: ty.List[str],
-        axes: type,
+        axes: ty.Type[Axes],
         **kwargs: ty.Any,
     ) -> DataTree:
         raise NotImplementedError


### PR DESCRIPTION
Add a run UID to differentiate between staged directories that are created from different runs (e.g. one created to stage DICOM process and another to stage raw data)