### PR TITLE
handle multiple values in get_id when constructing scans/sessions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]  # , macos-latest, windows-latest]
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11", "3.13"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -109,7 +109,7 @@ jobs:
         echo "TAG=$IMAGE:$VERSION" >> $GITHUB_OUTPUT
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v6
       with:
         cache-from: type=registry,ref=${{ steps.versions.outputs.IMAGE }}:buildcache
         cache-to: type=registry,ref=${{ steps.versions.outputs.IMAGE }}:buildcache,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:latest
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:24.10
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 ADD . /app
 
 # Install application
-RUN pip3 install /app
+RUN pip3 install --break-system-packages /app
 
 # Set application entrypoint to docker entrypoint
 ENTRYPOINT ["xnat-ingest"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ RUN apt-get update && apt-get install -y \
   git \
   mrtrix3 \
   curl \
-  zip \
-  && rm -rf /var/lib/apt/lists/*
+  zip
 
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
   && unzip awscliv2.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.10
+FROM ubuntu:latest
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ requires-python = ">=3.8"
 dependencies = [
     "click >=8.1",
     "discord",
-    "fileformats-medimage-extras",
+    "fileformats-medimage >=0.10.1",
+    "fileformats-medimage-extras >=0.10.1",
     "pydicom >=2.3.1",
     "tqdm >=4.64.1",
     "boto3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "xnat-ingest"
 description = "Uploads exported DICOM and raw data to XNAT, parsing metadata from DICOMs"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 dependencies = [
     "click >=8.1",
     "discord",
@@ -35,11 +35,9 @@ classifiers = [
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
 ]
 dynamic = ["version"]

--- a/xnat_ingest/cli/stage.py
+++ b/xnat_ingest/cli/stage.py
@@ -29,7 +29,10 @@ class CopyModeParamType(click.ParamType):
     name = "copy_mode"
 
     def convert(
-        self, value: str, param: ty.Optional[click.Parameter], ctx: ty.Optional[click.Context]
+        self,
+        value: str,
+        param: ty.Optional[click.Parameter],
+        ctx: ty.Optional[click.Context],
     ) -> FileSet.CopyMode:
         if isinstance(value, FileSet.CopyMode):
             return value
@@ -304,7 +307,7 @@ def stage(
             cache_dir=Path(tempfile.mkdtemp()),
         )
         with xnat_repo.connection:
-            project_list = list(xnat_repo.connection.projects)
+            project_list = [p.name for p in xnat_repo.connection.projects]
     else:
         project_list = None
 

--- a/xnat_ingest/session.py
+++ b/xnat_ingest/session.py
@@ -376,6 +376,9 @@ class ImagingSession:
                         )
                 if index is not None:
                     value = value[index]
+                elif isinstance(value, list):
+                    frequency = Counter(value)
+                    value = frequency.most_common(1)[0]
                 value_str = str(value)
                 value_str = invalid_path_chars_re.sub("_", value_str)
                 return value_str

--- a/xnat_ingest/tests/test_cli.py
+++ b/xnat_ingest/tests/test_cli.py
@@ -252,7 +252,7 @@ def test_stage_and_upload(
         xproject = xnat_login.projects[xnat_project]
         for session_id in session_ids:
             xsession = xproject.experiments[session_id]
-            scan_ids = sorted(xsession.scans)
+            scan_ids = sorted(s.name for s in xsession.scans)
 
             assert scan_ids == [
                 "1",

--- a/xnat_ingest/tests/test_cli.py
+++ b/xnat_ingest/tests/test_cli.py
@@ -252,7 +252,7 @@ def test_stage_and_upload(
         xproject = xnat_login.projects[xnat_project]
         for session_id in session_ids:
             xsession = xproject.experiments[session_id]
-            scan_ids = sorted(s.name for s in xsession.scans)
+            scan_ids = sorted(s.id for s in xsession.scans)
 
             assert scan_ids == [
                 "1",


### PR DESCRIPTION
When loading DICOMs, sometimes the fields used to extract the ID/type of the scan might have differing values across the series (e.g. maybe there are some special files included in it), in which case the DICOM metadata reader will return a list instead of a scalar value. To handle this case, we select the most common element in the list and use that for the ID instead