### PR TITLE
BUGFIX: Adds DatatypeStr cli class to handle splitting of datatype envvars

### DIFF
--- a/xnat_ingest/cli/stage.py
+++ b/xnat_ingest/cli/stage.py
@@ -13,6 +13,7 @@ from xnat_ingest.session import ImagingSession
 from frametree.xnat import Xnat  # type: ignore[import-untyped]
 from xnat_ingest.utils import (
     AssociatedFiles,
+    DatatypeStr,
     logger,
     LoggerConfig,
     XnatLogin,
@@ -58,7 +59,7 @@ are uploaded to XNAT
 @click.argument("output_dir", type=click.Path(path_type=Path))
 @click.option(
     "--datatype",
-    type=str,
+    type=DatatypeStr.cli_type,
     metavar="<mime-type>",
     multiple=True,
     default=None,

--- a/xnat_ingest/session.py
+++ b/xnat_ingest/session.py
@@ -15,8 +15,8 @@ import attrs
 from tqdm import tqdm
 from fileformats.medimage import MedicalImage, DicomSeries
 from fileformats.core import from_paths, FileSet, from_mime
-from frametree.core.frameset import FrameSet  # type: ignore[import-untyped]
-from frametree.core.exceptions import FrameTreeDataMatchError  # type: ignore[import-untyped]
+from frametree.core.frameset import FrameSet
+from frametree.core.exceptions import FrameTreeDataMatchError
 from .exceptions import ImagingSessionParseError, StagingError
 from .utils import AssociatedFiles, invalid_path_chars_re
 from .scan import ImagingScan
@@ -26,7 +26,7 @@ logger = logging.getLogger("xnat-ingest")
 
 
 def scans_converter(
-    scans: ty.Union[ty.Sequence[ImagingScan], ty.Dict[str, ImagingScan]]
+    scans: ty.Union[ty.Sequence[ImagingScan], ty.Dict[str, ImagingScan]],
 ) -> dict[str, ImagingScan]:
     if isinstance(scans, ty.Sequence):
         duplicates = [i for i, c in Counter(s.id for s in scans).items() if c > 1]

--- a/xnat_ingest/session.py
+++ b/xnat_ingest/session.py
@@ -213,9 +213,11 @@ class ImagingSession:
             k for k in set(chain(*all_keys)) if all(k in keys for keys in all_keys)
         ]
         collated = {k: primary_resources[0].metadata[k] for k in common_keys}
-        for i, series in enumerate(primary_resources[1:], start=1):
+        for i, resource in enumerate(primary_resources[1:], start=1):
             for key in common_keys:
-                val = series.metadata[key]
+                if not resource.metadata:
+                    continue
+                val = resource.metadata[key]
                 if val != collated[key]:
                     # Check whether the value is the same as the values in the previous
                     # images in the series
@@ -525,7 +527,7 @@ class ImagingSession:
                     scan_id,
                     scan_type,
                     resource_name,
-                    associated_files.datatype(fspath),
+                    from_paths([fspath], associated_files.datatype)[0],
                     associated=associated_files,
                 )
 

--- a/xnat_ingest/tests/test_cli.py
+++ b/xnat_ingest/tests/test_cli.py
@@ -196,7 +196,7 @@ def test_stage_and_upload(
             str(dicoms_dir),
             str(staging_dir),
             "--associated-files",
-            "medimage/vnd.siemens.biograph128-vision.vr20b.pet-raw-data",
+            "medimage/vnd.siemens.biograph128-vision.vr20b.pet-count-rate,medimage/vnd.siemens.biograph128-vision.vr20b.pet-list-mode",
             str(associated_files_dir)
             + "/{PatientName.family_name}_{PatientName.given_name}*.ptd",
             r".*/[^\.]+.[^\.]+.[^\.]+.(?P<id>\d+)\.[A-Z]+_(?P<resource>[^\.]+).*",

--- a/xnat_ingest/tests/test_session.py
+++ b/xnat_ingest/tests/test_session.py
@@ -272,7 +272,10 @@ def test_stage_raw_data_directly(raw_frameset: FrameSet, tmp_path: Path):
 
     imaging_sessions = ImagingSession.from_paths(
         f"{raw_data_dir}/**/*.ptd",
-        datatypes=[Vnd_Siemens_Biograph128Vision_Vr20b_PetRawData],
+        datatypes=[
+            Vnd_Siemens_Biograph128Vision_Vr20b_PetListMode,
+            Vnd_Siemens_Biograph128Vision_Vr20b_PetCountRate,
+        ],
     )
 
     staging_dir = tmp_path / "staging"

--- a/xnat_ingest/utils.py
+++ b/xnat_ingest/utils.py
@@ -16,7 +16,7 @@ logger = logging.getLogger("xnat-ingest")
 
 
 def datatype_converter(
-    datatype_str: ty.Union[str, ty.Type[DataType]]
+    datatype_str: ty.Union[str, ty.Type[DataType]],
 ) -> ty.Type[DataType]:
     if isinstance(datatype_str, str):
         return from_mime(datatype_str)
@@ -118,6 +118,10 @@ class StoreCredentials(CliTyped):
 
     access_key: str
     access_secret: str
+
+
+class DatatypeStr(str, CliTyped):
+    pass
 
 
 def set_logger_handling(


### PR DESCRIPTION
Handle the splitting of datatype mime-like strings in CLI envvars