### PR TITLE
Add handling to avoid resource name clashes

### DIFF
--- a/xnat_ingest/cli/stage.py
+++ b/xnat_ingest/cli/stage.py
@@ -274,6 +274,15 @@ are uploaded to XNAT
         "avoid uploading partial sessions"
     ),
 )
+@click.option(
+    "--avoid-clashes/--dont-avoid-clashes",
+    default=False,
+    envvar="XINGEST_AVOID_CLASHES",
+    help=(
+        "If a resource with the same name already exists in the scan, increment the "
+        "resource name by appending _1, _2 etc. to the name until a unique name is found"
+    ),
+)
 def stage(
     files_path: str,
     output_dir: Path,
@@ -301,6 +310,7 @@ def stage(
     deidentified_dir_name: str,
     loop: int | None,
     wait_period: int,
+    avoid_clashes: bool = False,
 ) -> None:
 
     if raise_errors and loop:
@@ -373,6 +383,7 @@ def stage(
             scan_desc_field=scan_desc_field,
             resource_field=resource_field,
             project_id=project_id,
+            avoid_clashes=avoid_clashes,
         )
 
         logger.info("Staging sessions to '%s'", str(output_dir))
@@ -396,11 +407,13 @@ def stage(
                     session.associate_files(
                         associated_files,
                         spaces_to_underscores=spaces_to_underscores,
+                        avoid_clashes=avoid_clashes,
                     )
                 if deidentify:
                     deidentified_session = session.deidentify(
                         deidentified_dir,
                         copy_mode=copy_mode,
+                        avoid_clashes=avoid_clashes,
                     )
                     if delete:
                         session.unlink()

--- a/xnat_ingest/cli/upload.py
+++ b/xnat_ingest/cli/upload.py
@@ -389,7 +389,17 @@ def upload(
                                 if num_files_per_batch > 0
                                 else num_files
                             )
-                            for i in range(int(math.ceil(num_files / batch_size))):
+                            num_batches = math.ceil(num_files / batch_size)
+                            logger.debug(
+                                "Uploading %s files to '%s' in %s in %s batches of %s files using '%s' method",
+                                num_files,
+                                resource.path,
+                                xresource,
+                                num_batches,
+                                batch_size,
+                                upload_method,
+                            )
+                            for i in range(num_batches):
                                 # Create a temporary directory to upload the batch from
                                 if upload_dir.exists():
                                     shutil.rmtree(upload_dir)
@@ -402,8 +412,9 @@ def upload(
                                     )
                                     dest.hardlink_to(fspath)
                                 logger.debug(
-                                    "Uploading batch %s of '%s' to %s with '%s' method",
+                                    "Uploading batch %s of %s of '%s' to %s with '%s' method",
                                     i,
+                                    num_batches,
                                     upload_dir,
                                     xresource,
                                     upload_method,


### PR DESCRIPTION
If there is a resource name clash, checksums are compared to see if they are the same file, otherwise they can be overwritten or the resource name incremented by appending a `__N` suffix to avoid the name clash (if `--avoid-clashes` is set)