### PR TITLE
bug-fix in upload error

### DIFF
--- a/xnat_ingest/cli/upload.py
+++ b/xnat_ingest/cli/upload.py
@@ -497,7 +497,7 @@ def upload(
                 except Exception as e:
                     if not raise_errors:
                         logger.error(
-                            f"Skipping '{session.name}' session due to error uploading: \"{e}\""
+                            f"Skipping upload of '{str(session_staging_dir)}' due to error: \"{e}\""
                             f"\n{traceback.format_exc()}\n\n"
                         )
                         continue


### PR DESCRIPTION
When an upload of a session fails the exception is caught, but the message was referencing an object that may not have been created yet.
Changed to reference the session directory to be uploaded instead