### PR TITLE
saving metadata in separate file for future reference

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ classifiers = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-dev = ["black", "pre-commit", "codespell", "flake8", "flake8-pyproject"]
+dev = ["black", "pre-commit", "codespell", "flake8", "flake8-pyproject", "isort"]
 test = [
     "pytest >=6.2.5",
     "pytest-env>=0.6.2",
@@ -80,6 +80,12 @@ exclude = ["/tests"]
 [tool.black]
 target-version = ['py37', 'py38']
 exclude = "xnat_ingest/_version.py"
+
+[tool.isort]
+profile = "black"
+multi_line_mode = 3
+line_length = 88
+skip_gitignore = true
 
 [tool.codespell]
 ignore-words = ".codespell-ignorewords"

--- a/xnat_ingest/api/__init__.py
+++ b/xnat_ingest/api/__init__.py
@@ -1,7 +1,16 @@
 from .associate_ import associate
 from .check_upload_ import check_upload
 from .deidentify_ import deidentify
-from .sort_ import sort
+from .sort_ import sort, list_session_dirs, BUILD_NAME_DEFAULT, INVALID_NAME_DEFAULT
 from .upload_ import upload
 
-__all__ = ["upload", "check_upload", "sort", "deidentify", "associate"]
+__all__ = [
+    "upload",
+    "check_upload",
+    "sort",
+    "deidentify",
+    "associate",
+    "list_session_dirs",
+    "BUILD_NAME_DEFAULT",
+    "INVALID_NAME_DEFAULT",
+]

--- a/xnat_ingest/api/associate_.py
+++ b/xnat_ingest/api/associate_.py
@@ -10,6 +10,7 @@ from xnat_ingest.helpers.remotes import LocalSessionListing
 from ..helpers.arg_types import AssociatedFiles
 from ..helpers.logging import logger
 from ..model.session import ImagingSession
+from .sort_ import list_session_dirs
 
 
 def associate(
@@ -25,7 +26,7 @@ def associate(
 ) -> list[str]:
 
     sessions: list[LocalSessionListing] = [
-        LocalSessionListing(p) for p in Path(input_dir).iterdir()
+        LocalSessionListing(p) for p in list_session_dirs(input_dir)
     ]
     num_sessions = len(sessions)
     logger.info(
@@ -48,7 +49,7 @@ def associate(
                 require_manifest=require_manifest,
                 check_checksums=False,
             )
-            session.associate_files(
+            associated = session.associate_files(
                 associated_files,
                 spaces_to_underscores=spaces_to_underscores,
                 avoid_clashes=avoid_clashes,
@@ -59,9 +60,12 @@ def associate(
                 raise
             logger.error(
                 "Error associating files for session '%s': %s",
-                session_listing.session_dir,
+                session_listing.name,
                 str(e),
             )
             logger.debug(traceback.format_exc())
             errors.append(str(e))
+        else:
+            if delete:
+                associated.unlink()
     return errors

--- a/xnat_ingest/api/sort_.py
+++ b/xnat_ingest/api/sort_.py
@@ -3,14 +3,19 @@ import time
 import traceback
 from pathlib import Path
 
-from fileformats.application import Json
+from fileformats.application import Yaml
 from fileformats.core import FileSet
+from filelock import SoftFileLock
 from frametree.xnat import Xnat
 from tqdm import tqdm
 
 from ..helpers.arg_types import FieldSpec, XnatLogin
 from ..helpers.logging import logger
 from ..model.session import ImagingSession
+
+
+BUILD_NAME_DEFAULT = "__build__"
+INVALID_NAME_DEFAULT = "__invalid__"
 
 
 def sort(
@@ -110,8 +115,8 @@ def sort(
 
     # Create sub-directories of the output directory for the different phases of the
     # staging process
-    build_dir = output_dir / "__build__"
-    invalid_dir = output_dir / "__invalid__"
+    build_dir = output_dir / BUILD_NAME_DEFAULT
+    invalid_dir = output_dir / INVALID_NAME_DEFAULT
 
     build_dir.mkdir(parents=True, exist_ok=True)
     invalid_dir.mkdir(parents=True, exist_ok=True)
@@ -169,21 +174,58 @@ def sort(
             if "INVALID" in saved_dir.name:
                 saved_dir.rename(invalid_dir / saved_dir.relative_to(build_dir))
             else:
-                saved_dir.rename(output_dir / saved_dir.relative_to(build_dir))
-            # Hardlink the metadata file from the build directory to the metadata directory
-            # if save_metadata is True. This ensures that the metadata file is not moved or
-            # deleted until the session is moved from the build directory to the output directory.
-            if save_metadata and isinstance(save_metadata, bool):
-                logger.debug(
-                    "Hardlinking metadata file for session '%s' from '%s' to '%s'",
-                    session.name,
-                    saved_dir / "METADATA.json",
-                    metadata_dir / f"{session.name}.json",
-                )
-                Json(output_dir / session.name / "METADATA.json").copy(
-                    metadata_dir / f"{session.name}.json",
-                    mode=FileSet.CopyMode.hardlink,
-                )
+                session_output_dir = output_dir / saved_dir.relative_to(build_dir)
+                with SoftFileLock(session_output_dir.with_suffix(".lock")):
+                    if session_output_dir.exists():
+                        logger.info(
+                            "Merging sorted session '%s' into existing directory '%s'",
+                            saved_dir.name,
+                            session_output_dir,
+                        )
+                        for scan_dir in saved_dir.iterdir():
+                            if scan_dir.is_dir():
+                                scan_dir.rename(session_output_dir / scan_dir.name)
+                        exist_mdata_path = (
+                            session_output_dir / session.DEFAULT_METADATA_FNAME
+                        )
+                        new_mdata_path = saved_dir / session.DEFAULT_METADATA_FNAME
+                        if new_mdata_path.exists():
+                            if exist_mdata_path.exists():
+                                # Merge metadata files
+                                mdata = Yaml(exist_mdata_path).load()
+                                new_mdata = Yaml(new_mdata_path).load()
+                                for key in set(mdata) & set(new_mdata):
+                                    if mdata[key] != new_mdata[key]:
+                                        raise ValueError(
+                                            f"Conflict in metadata for key '{key}' between existing session at "
+                                            f"'{exist_mdata_path}' and new session at '{new_mdata_path}'"
+                                        )
+                                mdata.update(new_mdata)
+                                Yaml(exist_mdata_path).save(mdata)
+                            else:
+                                new_mdata_path.rename(exist_mdata_path)
+                        if remaining := list(saved_dir.iterdir()):
+                            raise ValueError(
+                                f"Unexpected files/directories {remaining} found in saved session directory '{saved_dir}' "
+                                f"after merging with existing session directory '{session_output_dir}'"
+                            )
+                        saved_dir.rmdir()
+                    else:
+                        saved_dir.rename(session_output_dir)
+                # Hardlink the metadata file from the build directory to the metadata directory
+                # if save_metadata is True. This ensures that the metadata file is not moved or
+                # deleted until the session is moved from the build directory to the output directory.
+                if save_metadata and isinstance(save_metadata, bool):
+                    src_path = session_output_dir / session.DEFAULT_METADATA_FNAME
+                    target_fpath = metadata_dir / f"{session.name}.yaml"
+                    logger.debug(
+                        "Hardlinking metadata file for session '%s' from '%s' to '%s'",
+                        session.name,
+                        src_path,
+                        target_fpath,
+                    )
+                    target_fpath.hardlink_to(src_path)
+
             if delete:
                 session.unlink()
         except Exception as e:
@@ -199,3 +241,16 @@ def sort(
                 raise
 
     return errors
+
+
+def list_session_dirs(sorted_dir: Path) -> list[Path]:
+    """List the session directories in the sorted directory, excluding any directories that start with '__'"""
+
+    return [
+        p
+        for p in Path(sorted_dir).iterdir()
+        if p.is_dir()
+        and not p.name.startswith("__")
+        and not p.name.endswith("__")
+        and "." not in p.name
+    ]

--- a/xnat_ingest/api/upload_.py
+++ b/xnat_ingest/api/upload_.py
@@ -28,6 +28,7 @@ from xnat_ingest.helpers.remotes import (
 from ..helpers.arg_types import StoreCredentials, UploadMethod
 from ..helpers.logging import logger
 from ..model.session import ImagingSession
+from . import list_session_dirs
 
 
 def upload(
@@ -126,7 +127,7 @@ def upload(
             num_sessions = next(sessions)  # type: ignore[assignment]
         else:
             sessions = []
-            for session_dir in Path(input_dir).iterdir():
+            for session_dir in list_session_dirs(input_dir):
                 if dir_older_than(session_dir, wait_period):
                     sessions.append(LocalSessionListing(session_dir))
                 else:

--- a/xnat_ingest/cli/sort.py
+++ b/xnat_ingest/cli/sort.py
@@ -19,9 +19,6 @@ from ..helpers.arg_types import (
 )
 from ..helpers.logging import logger, set_logger_handling
 
-BUILDING_NAME_DEFAULT = "BUILDING"
-SORTED_NAME_DEFAULT = "SORTED"
-INVALID_NAME_DEFAULT = "INVALID"
 
 
 @base_cli.command(

--- a/xnat_ingest/cli/tests/test_cli.py
+++ b/xnat_ingest/cli/tests/test_cli.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import click
 import xnat4tests  # type: ignore[import-untyped]
-from fileformats.application import Json
+from fileformats.application import Json, Yaml
 from fileformats.medimage import DicomSeries
 from fileformats.testing import MyFormat, MyFormatGz
 from frametree.core.cli import add_source as dataset_add_source
@@ -30,7 +30,7 @@ from moto import mock_aws
 
 from conftest import get_raw_data_files, show_cli_trace
 from xnat_ingest.cli import associate_cli, check_upload_cli, sort_cli, upload_cli
-from xnat_ingest.cli.sort import INVALID_NAME_DEFAULT, SORTED_NAME_DEFAULT
+from xnat_ingest.api import INVALID_NAME_DEFAULT, list_session_dirs
 from xnat_ingest.helpers.arg_types import MimeType  # type: ignore[import-untyped]
 from xnat_ingest.helpers.arg_types import FieldSpec, XnatLogin
 from xnat_ingest.helpers.remotes import upload_file_to_s3
@@ -244,7 +244,7 @@ def test_stage_and_upload(
     associated_files_dir = tmp_path / "non-dicoms"
     associated_files_dir.mkdir(exist_ok=True)
 
-    sorted_dir = tmp_path / "staging"
+    sorted_dir = tmp_path / "sorted"
     if sorted_dir.exists():
         shutil.rmtree(sorted_dir)
     sorted_dir.mkdir()
@@ -267,13 +267,16 @@ def test_stage_and_upload(
 
     # Delete any existing sessions from previous test runs
     session_ids = []
+    session_names = []
     with xnat4tests.connect() as xnat_login:
         for i, c in enumerate("abc"):
             first_name = f"First{c.upper()}"
             last_name = f"Last{c.upper()}"
             PatientID = f"subject{i}"
-            AccessionNumber = f"98765432{i}"
-            session_ids.append(f"{PatientID}_{AccessionNumber}")
+            AccessionNumber = f"987654321{i}"
+            session_id = f"{PatientID}_{AccessionNumber}"
+            session_ids.append(session_id)
+            session_names.append(f"{project_id}-{PatientID}-{AccessionNumber}")
 
             StudyInstanceUID = (
                 f"1.3.12.2.1107.5.1.4.10016.3000002308242209356530000001{i}"
@@ -432,9 +435,9 @@ def test_stage_and_upload(
     stdout_logs = result.stdout
     assert "Staging completed successfully" in stdout_logs, show_cli_trace(result)
 
-    mdata_path = sorted_dir / "__metadata__" / f"{session_ids[0]}.json"
+    mdata_path = sorted_dir / "__metadata__" / f"{session_names[0]}.yaml"
     assert mdata_path.exists(), show_cli_trace(result)
-    mdata = Json(mdata_path).load()  # Check that the metadata file is valid JSON
+    mdata = Yaml(mdata_path).load()  # Check that the metadata file is valid JSON
     assert mdata.get("PatientID") == "subject0", show_cli_trace(result)
 
     associated_dir = tmp_path / "associated"
@@ -442,7 +445,7 @@ def test_stage_and_upload(
     result = cli_runner(
         associate_cli,
         [
-            str(sorted_dir / SORTED_NAME_DEFAULT),
+            str(sorted_dir),
             str(associated_dir),
             "--associated-files",
             "medimage/vnd.siemens.syngo-mi.vr20b.count-rate|medimage/vnd.siemens.syngo-mi.vr20b.list-mode",
@@ -588,13 +591,11 @@ def test_stage_wait_period(
 ) -> None:
     # Get test image data
 
-    staging_dir = tmp_path / "staging"
+    sorted_dir = tmp_path / "sorted"
     dicoms_path = tmp_path / "dicoms"
-    if staging_dir.exists():
-        shutil.rmtree(staging_dir)
-    staging_dir.mkdir()
-
-    staged_dir = staging_dir / SORTED_NAME_DEFAULT
+    if sorted_dir.exists():
+        shutil.rmtree(sorted_dir)
+    sorted_dir.mkdir()
 
     stage_log_file = tmp_path / "stage-logs.log"
     if stage_log_file.exists():
@@ -607,7 +608,7 @@ def test_stage_wait_period(
         sort_cli,
         [
             str(dicoms_path),
-            str(staging_dir),
+            str(sorted_dir),
             "--raise-errors",
             "--delete",
             "--wait-period",
@@ -621,7 +622,9 @@ def test_stage_wait_period(
     assert result.exit_code == 0, show_cli_trace(result)
     logs = stage_log_file.read_text()
     assert " as it was last modified " in logs, show_cli_trace(result)
-    assert not list(staged_dir.iterdir())
+    assert not [
+        p for p in sorted_dir.iterdir() if not p.name.startswith("__")
+    ], show_cli_trace(result)
 
     time.sleep(10)
 
@@ -629,7 +632,7 @@ def test_stage_wait_period(
         sort_cli,
         [
             str(dicoms_path),
-            str(staging_dir),
+            str(sorted_dir),
             "--raise-errors",
             "--delete",
             "--wait-period",
@@ -643,7 +646,7 @@ def test_stage_wait_period(
     assert result.exit_code == 0, show_cli_trace(result)
     logs = stage_log_file.read_text()
     assert "Successfully staged " in logs, show_cli_trace(result)
-    assert list(staged_dir.iterdir())
+    assert list(sorted_dir.iterdir())
 
 
 def test_stage_invalid_ids(
@@ -653,14 +656,13 @@ def test_stage_invalid_ids(
 ) -> None:
     # Get test image data
 
-    staging_dir = tmp_path / "staging"
+    sorted_dir = tmp_path / "sorted"
     dicoms_path = tmp_path / "dicoms"
-    if staging_dir.exists():
-        shutil.rmtree(staging_dir)
-    staging_dir.mkdir()
+    if sorted_dir.exists():
+        shutil.rmtree(sorted_dir)
+    sorted_dir.mkdir()
 
-    staged_dir = staging_dir / SORTED_NAME_DEFAULT
-    invalid_dir = staging_dir / INVALID_NAME_DEFAULT
+    invalid_dir = sorted_dir / INVALID_NAME_DEFAULT
 
     stage_log_file = tmp_path / "stage-logs.log"
     if stage_log_file.exists():
@@ -673,7 +675,7 @@ def test_stage_invalid_ids(
         sort_cli,
         [
             str(dicoms_path),
-            str(staging_dir),
+            str(sorted_dir),
             "--subject-field",
             "PatientID",
             "generic/file-set",
@@ -687,7 +689,7 @@ def test_stage_invalid_ids(
     assert result.exit_code == 0, show_cli_trace(result)
     logs = stage_log_file.read_text()
     assert "-INVALID_MISSING_PATIENTID_" in logs, show_cli_trace(result)
-    assert not list(staged_dir.iterdir())
+    assert not list_session_dirs(sorted_dir)
     assert len(list(invalid_dir.iterdir())) == 1
 
 
@@ -707,7 +709,7 @@ def test_check_upload_missing_scan(
         xnat_login.put(f"/data/archive/projects/{project_id}")
 
     inputs_dir = tmp_path / "inputs"
-    staging_dir = tmp_path / "staging"
+    sorted_dir = tmp_path / "sorted"
     check_upload_log_file = tmp_path / "check-upload-logs.log"
 
     session_metadata = {
@@ -737,7 +739,7 @@ def test_check_upload_missing_scan(
         sort_cli,
         [
             str(inputs_dir),
-            str(staging_dir),
+            str(sorted_dir),
             "--raise-errors",
             "--delete",
             "--wait-period",
@@ -752,7 +754,7 @@ def test_check_upload_missing_scan(
     assert result.exit_code == 0, show_cli_trace(result)
 
     source_dir = transfer_to_source(
-        staging_dir / SORTED_NAME_DEFAULT,
+        sorted_dir,
         upload_source=upload_source,
         s3_bucket=s3_bucket,
         s3_prefix=project_id,
@@ -824,7 +826,7 @@ def test_check_upload_empty_scan(
         xnat_login.put(f"/data/archive/projects/{project_id}")
 
     inputs_dir = tmp_path / "inputs"
-    staging_dir = tmp_path / "staging"
+    sorted_dir = tmp_path / "sorted"
     check_upload_log_file = tmp_path / "check-upload-logs.log"
 
     session_metadata = {
@@ -854,7 +856,7 @@ def test_check_upload_empty_scan(
         sort_cli,
         [
             str(inputs_dir),
-            str(staging_dir),
+            str(sorted_dir),
             "--raise-errors",
             "--delete",
             "--wait-period",
@@ -869,7 +871,7 @@ def test_check_upload_empty_scan(
     assert result.exit_code == 0, show_cli_trace(result)
 
     source_dir = transfer_to_source(
-        staging_dir / SORTED_NAME_DEFAULT,
+        sorted_dir,
         upload_source=upload_source,
         s3_bucket=s3_bucket,
         s3_prefix=project_id,
@@ -948,7 +950,7 @@ def test_check_upload_missing_resource(
         xnat_login.put(f"/data/archive/projects/{project_id}")
 
     inputs_dir = tmp_path / "inputs"
-    staging_dir = tmp_path / "staging"
+    sorted_dir = tmp_path / "sorted"
     check_upload_log_file = tmp_path / "check-upload-logs.log"
 
     session_metadata = {
@@ -979,7 +981,7 @@ def test_check_upload_missing_resource(
         sort_cli,
         [
             str(inputs_dir),
-            str(staging_dir),
+            str(sorted_dir),
             "--raise-errors",
             "--delete",
             "--wait-period",
@@ -994,7 +996,7 @@ def test_check_upload_missing_resource(
     assert result.exit_code == 0, show_cli_trace(result)
 
     source_dir = transfer_to_source(
-        staging_dir / SORTED_NAME_DEFAULT,
+        sorted_dir,
         upload_source=upload_source,
         s3_bucket=s3_bucket,
         s3_prefix=project_id,
@@ -1073,8 +1075,7 @@ def test_check_upload_checksum_fail(
         xnat_login.put(f"/data/archive/projects/{project_id}")
 
     inputs_dir = tmp_path / "inputs"
-    staging_dir = tmp_path / "staging"
-    staged_dir = str(staging_dir / SORTED_NAME_DEFAULT)
+    sorted_dir = tmp_path / "sorted"
     check_upload_log_file = tmp_path / "check-upload-logs.log"
 
     session_metadata = {
@@ -1103,7 +1104,7 @@ def test_check_upload_checksum_fail(
         sort_cli,
         [
             str(inputs_dir),
-            str(staging_dir),
+            str(sorted_dir),
             "--raise-errors",
             "--delete",
             "--wait-period",
@@ -1122,7 +1123,7 @@ def test_check_upload_checksum_fail(
     result = cli_runner(
         upload_cli,
         [
-            str(staging_dir / SORTED_NAME_DEFAULT),
+            str(sorted_dir),
             "--always-include",
             "testing/my-format-x",
             "--raise-errors",
@@ -1142,7 +1143,7 @@ def test_check_upload_checksum_fail(
     assert result.exit_code == 0, show_cli_trace(result)
 
     manifest_file = Json(
-        next(next(next(Path(staged_dir).iterdir()).iterdir()).iterdir())
+        next(next(next(iter(list_session_dirs(sorted_dir))).iterdir()).iterdir())
         / "MANIFEST.json"
     )
     manifest_data = manifest_file.load()
@@ -1152,7 +1153,7 @@ def test_check_upload_checksum_fail(
     manifest_file.save(manifest_data)
 
     source_dir = transfer_to_source(
-        staging_dir / SORTED_NAME_DEFAULT,
+        sorted_dir,
         upload_source=upload_source,
         s3_bucket=s3_bucket,
         s3_prefix=project_id,

--- a/xnat_ingest/helpers/remotes.py
+++ b/xnat_ingest/helpers/remotes.py
@@ -193,6 +193,8 @@ def iterate_s3_sessions(
             continue  # skip directories
         path_parts = obj.key[len(prefix) :].split("/")
         session_name = path_parts[0]
+        if session_name.startswith("__") and session_name.endswith("__"):
+            continue  # skip internal directories
         session_objs[session_name].append((path_parts[1:], obj))
 
     num_sessions = len(session_objs)

--- a/xnat_ingest/model/session.py
+++ b/xnat_ingest/model/session.py
@@ -6,13 +6,14 @@ import platform
 import re
 import typing as ty
 from collections import Counter, defaultdict
-from datetime import date, datetime, time
+from datetime import datetime
 from functools import cached_property
 from glob import glob
 from itertools import chain
 from pathlib import Path
 
 import attrs
+import yaml
 from fileformats.core import FileSet, from_mime, from_paths
 from fileformats.medimage import DicomCollection, MedicalImage
 from frametree.core.exceptions import FrameTreeDataMatchError
@@ -67,6 +68,8 @@ class ImagingSession:
         validator=attrs.validators.instance_of(dict),
     )
     run_uid: ty.Optional[str] = attrs.field(default=None)
+
+    DEFAULT_METADATA_FNAME = "METADATA.yaml"
 
     def __attrs_post_init__(self) -> None:
         for scan in self.scans.values():
@@ -560,7 +563,7 @@ class ImagingSession:
         patterns: ty.List[AssociatedFiles],
         spaces_to_underscores: bool = True,
         avoid_clashes: bool = False,
-    ) -> None:
+    ) -> list[FileSet]:
         """Adds files associated with the primary files to the session
 
         Parameters
@@ -571,6 +574,7 @@ class ImagingSession:
             when building associated file globs, convert spaces underscores in fields
             extracted from source file metadata, false by default
         """
+        all_associated = []
         for associated_files in patterns:
             # substitute string templates int the glob template with values from the
             # DICOM metadata to construct a glob pattern to select files associated
@@ -608,14 +612,17 @@ class ImagingSession:
                     scan_type = match.group("type")
                 except IndexError:
                     scan_type = scan_id
+                fspaths = from_paths([fspath], associated_files.datatype)
                 self.add_resource(
                     scan_id,
                     scan_type,
                     resource_name,
-                    from_paths([fspath], associated_files.datatype)[0],
+                    fspaths[0],
                     associated=associated_files,
                     avoid_clashes=avoid_clashes,
                 )
+                all_associated.extend(fspaths)
+        return all_associated
 
     def add_resource(
         self,
@@ -805,8 +812,8 @@ class ImagingSession:
             the mode to use to copy the files that don't need to be deidentified,
             by default FileSet.CopyMode.hardlink_or_copy
         save_metadata : bool or Path, optional
-            whether to save the session metadata to a JSON file in the session directory,
-            if True, the metadata will be saved to a file named "METADATA.json" in the session
+            whether to save the session metadata to a YAML file in the session directory,
+            if True, the metadata will be saved to a file named "METADATA.yaml" in the session
             directory, if a Path, the metadata will be saved to this path, by default False
 
         Returns
@@ -832,13 +839,13 @@ class ImagingSession:
             saved.scans[saved_scan.id] = saved_scan
         if save_metadata:
             metadata_path = (
-                session_dir / "METADATA.json"
+                session_dir / self.DEFAULT_METADATA_FNAME
                 if save_metadata is True
                 else save_metadata
             )
             logger.debug("Saving session metadata to '%s'", metadata_path)
             with open(metadata_path, "w") as f:
-                json.dump(sanitize_for_json(self.metadata), f, indent=4)
+                yaml.dump(self.metadata, f, indent=4)
         return saved, session_dir
 
     MANIFEST_FILENAME = "MANIFEST.yaml"


### PR DESCRIPTION
Session metadata are saved in a separate YAML files that can be read independently from the session data, for use in the associate command step