### PR TITLE
Flatten file structure with --collate-resources flag

### DIFF
--- a/xnat_ingest/api/sort_.py
+++ b/xnat_ingest/api/sort_.py
@@ -1,6 +1,7 @@
 import tempfile
 import time
 import traceback
+import typing as ty
 from pathlib import Path
 
 from fileformats.application import Yaml
@@ -33,7 +34,7 @@ def sort(
     delete: bool = False,
     raise_errors: bool = False,
     copy_mode: FileSet.CopyMode = FileSet.CopyMode.hardlink_or_copy,
-    collation: FileSet.CopyCollation = FileSet.CopyCollation.any,
+    collate_datatypes: tuple[ty.Type[FileSet], ...] = (),
     wait_period: int = 0,
     avoid_clashes: bool = False,
     recursive: bool = False,
@@ -165,7 +166,7 @@ def sort(
                 build_dir,
                 available_projects=project_list,
                 copy_mode=copy_mode,
-                collation=collation,
+                collate_datatypes=collate_datatypes,
                 save_metadata=save_metadata,
             )
             if "INVALID" in saved_dir.name:

--- a/xnat_ingest/api/sort_.py
+++ b/xnat_ingest/api/sort_.py
@@ -34,7 +34,7 @@ def sort(
     delete: bool = False,
     raise_errors: bool = False,
     copy_mode: FileSet.CopyMode = FileSet.CopyMode.hardlink_or_copy,
-    collate_datatypes: tuple[ty.Type[FileSet], ...] = (),
+    collation_map: dict[ty.Type[FileSet], FileSet.CopyCollation] | None = None,
     wait_period: int = 0,
     avoid_clashes: bool = False,
     recursive: bool = False,
@@ -166,7 +166,7 @@ def sort(
                 build_dir,
                 available_projects=project_list,
                 copy_mode=copy_mode,
-                collate_datatypes=collate_datatypes,
+                collation_map=collation_map,
                 save_metadata=save_metadata,
             )
             if "INVALID" in saved_dir.name:

--- a/xnat_ingest/api/sort_.py
+++ b/xnat_ingest/api/sort_.py
@@ -33,6 +33,7 @@ def sort(
     delete: bool = False,
     raise_errors: bool = False,
     copy_mode: FileSet.CopyMode = FileSet.CopyMode.hardlink_or_copy,
+    collation: FileSet.CopyCollation = FileSet.CopyCollation.any,
     wait_period: int = 0,
     avoid_clashes: bool = False,
     recursive: bool = False,
@@ -164,6 +165,7 @@ def sort(
                 build_dir,
                 available_projects=project_list,
                 copy_mode=copy_mode,
+                collation=collation,
                 save_metadata=save_metadata,
             )
             if "INVALID" in saved_dir.name:

--- a/xnat_ingest/cli/sort.py
+++ b/xnat_ingest/cli/sort.py
@@ -11,6 +11,7 @@ from xnat_ingest.cli.base import base_cli
 
 from ..api.sort_ import sort
 from ..helpers.arg_types import (
+    CollationSpec,
     CopyModeParamType,
     FieldSpec,
     LoggerConfig,
@@ -236,14 +237,16 @@ are uploaded to XNAT
 )
 @click.option(
     "--collate-resources",
-    type=MimeType.cli_type,
-    metavar="<mime-type>",
+    type=CollationSpec.cli_type,
+    metavar="<mime-type> <collation>",
+    nargs=2,
     multiple=True,
     default=(),
     envvar="XINGEST_COLLATE_RESOURCES",
     help=(
         "Flatten files of the given datatype into the resource directory during sort, "
         "regardless of source directory structure (e.g. when sorting from Orthanc). "
+        "Collation level is one of 'any', 'siblings', or 'adjacent' (default 'siblings'). "
     ),
 )
 def sort_cli(
@@ -269,7 +272,7 @@ def sort_cli(
     recursive: bool,
     copy_mode: FileSet.CopyMode,
     save_metadata: bool,
-    collate_resources: tuple[MimeType, ...],
+    collate_resources: tuple[CollationSpec, ...],
 ) -> None:
 
     if raise_errors and loop >= 0:
@@ -311,7 +314,7 @@ def sort_cli(
             recursive=recursive,
             xnat_login=xnat_login,
             save_metadata=save_metadata,
-            collate_datatypes=tuple(mt.datatype for mt in collate_resources),
+            collation_map={cs.datatype: cs.collation_level for cs in collate_resources},
         )
         if errors:
             logger.error(

--- a/xnat_ingest/cli/sort.py
+++ b/xnat_ingest/cli/sort.py
@@ -235,12 +235,15 @@ are uploaded to XNAT
     envvar="XINGEST_SAVE_METADATA",
 )
 @click.option(
-    "--collate-resources/--dont-collate-resources",
-    default=False,
+    "--collate-resources",
+    type=MimeType.cli_type,
+    metavar="<mime-type>",
+    multiple=True,
+    default=(),
     envvar="XINGEST_COLLATE_RESOURCES",
     help=(
-        "Flatten files into the resource directory during sort, regardless of source "
-        "directory structure (e.g. when sorting from Orthanc) (XINGEST_COLLATE_RESOURCES env. var)"
+        "Flatten files of the given datatype into the resource directory during sort, "
+        "regardless of source directory structure (e.g. when sorting from Orthanc). "
     ),
 )
 def sort_cli(
@@ -266,7 +269,7 @@ def sort_cli(
     recursive: bool,
     copy_mode: FileSet.CopyMode,
     save_metadata: bool,
-    collate_resources: bool,
+    collate_resources: tuple[MimeType, ...],
 ) -> None:
 
     if raise_errors and loop >= 0:
@@ -308,7 +311,7 @@ def sort_cli(
             recursive=recursive,
             xnat_login=xnat_login,
             save_metadata=save_metadata,
-            collation=(FileSet.CopyCollation.siblings if collate_resources else FileSet.CopyCollation.any),
+            collate_datatypes=tuple(mt.datatype for mt in collate_resources),
         )
         if errors:
             logger.error(

--- a/xnat_ingest/cli/sort.py
+++ b/xnat_ingest/cli/sort.py
@@ -234,6 +234,15 @@ are uploaded to XNAT
     ),
     envvar="XINGEST_SAVE_METADATA",
 )
+@click.option(
+    "--collate-resources/--dont-collate-resources",
+    default=False,
+    envvar="XINGEST_COLLATE_RESOURCES",
+    help=(
+        "Flatten files into the resource directory during sort, regardless of source "
+        "directory structure (e.g. when sorting from Orthanc) (XINGEST_COLLATE_RESOURCES env. var)"
+    ),
+)
 def sort_cli(
     input_paths: list[str],
     staging_dir: Path,
@@ -257,6 +266,7 @@ def sort_cli(
     recursive: bool,
     copy_mode: FileSet.CopyMode,
     save_metadata: bool,
+    collate_resources: bool,
 ) -> None:
 
     if raise_errors and loop >= 0:
@@ -298,6 +308,7 @@ def sort_cli(
             recursive=recursive,
             xnat_login=xnat_login,
             save_metadata=save_metadata,
+            collation=(FileSet.CopyCollation.siblings if collate_resources else FileSet.CopyCollation.any),
         )
         if errors:
             logger.error(

--- a/xnat_ingest/helpers/arg_types.py
+++ b/xnat_ingest/helpers/arg_types.py
@@ -257,6 +257,21 @@ class MimeType(str, MultiCliTyped):
         return from_mime(self.mime)
 
 
+@attrs.define
+class CollationSpec(MultiCliTyped):
+
+    mime: str
+    collation: str = attrs.field(default="siblings")
+
+    @property
+    def datatype(self) -> ty.Type[DataType]:
+        return from_mime(self.mime)
+
+    @property
+    def collation_level(self) -> FileSet.CopyCollation:
+        return FileSet.CopyCollation[self.collation.lower()]
+
+
 class CopyModeParamType(click.ParamType):
     name = "copy_mode"
 

--- a/xnat_ingest/model/resource.py
+++ b/xnat_ingest/model/resource.py
@@ -77,6 +77,7 @@ class ImagingResource:
         self,
         dest_dir: Path,
         copy_mode: FileSet.CopyMode = FileSet.CopyMode.copy,
+        collation: FileSet.CopyCollation = FileSet.CopyCollation.any,
         calculate_checksums: bool = True,
         overwrite: bool | None = None,
     ) -> Self:
@@ -141,10 +142,11 @@ class ImagingResource:
                     "incomplete, overwriting"
                 )
                 shutil.rmtree(resource_dir)
-        saved_fileset = self.fileset.copy(resource_dir, mode=copy_mode, trim=True)
-        manifest = {"datatype": self.fileset.mime_like, "checksums": checksums}
+        saved_fileset = self.fileset.copy(resource_dir, mode=copy_mode, trim=True, collation=collation)
+        saved_checksums = saved_fileset.hash_files(crypto=hashlib.md5, relative_to=resource_dir)
+        manifest = {"datatype": self.fileset.mime_like, "checksums": saved_checksums}
         Json.new(resource_dir / self.MANIFEST_FNAME, manifest)
-        return type(self)(name=self.name, fileset=saved_fileset, checksums=checksums)
+        return type(self)(name=self.name, fileset=saved_fileset, checksums=saved_checksums)
 
     @classmethod
     def load(
@@ -159,7 +161,7 @@ class ImagingResource:
         from the files that were found
         """
         manifest_file = resource_dir / cls.MANIFEST_FNAME
-        fspaths = [p for p in resource_dir.iterdir() if p.name != cls.MANIFEST_FNAME]
+        fspaths = [p for p in resource_dir.rglob("*") if p.is_file() and p.name != cls.MANIFEST_FNAME]
         if manifest_file.exists():
             manifest = Json(manifest_file).load()
             checksums = manifest["checksums"]

--- a/xnat_ingest/model/resource.py
+++ b/xnat_ingest/model/resource.py
@@ -77,7 +77,7 @@ class ImagingResource:
         self,
         dest_dir: Path,
         copy_mode: FileSet.CopyMode = FileSet.CopyMode.copy,
-        collate_datatypes: tuple[ty.Type[FileSet], ...] = (),
+        collation_map: dict[ty.Type[FileSet], FileSet.CopyCollation] | None = None,
         calculate_checksums: bool = True,
         overwrite: bool | None = None,
     ) -> Self:
@@ -142,11 +142,12 @@ class ImagingResource:
                     "incomplete, overwriting"
                 )
                 shutil.rmtree(resource_dir)
-        collation = (
-            FileSet.CopyCollation.siblings
-            if collate_datatypes and isinstance(self.fileset, collate_datatypes)
-            else FileSet.CopyCollation.any
-        )
+        collation = FileSet.CopyCollation.any
+        if collation_map:
+            for dtype, coll_level in collation_map.items():
+                if isinstance(self.fileset, dtype):
+                    collation = coll_level
+                    break
         saved_fileset = self.fileset.copy(resource_dir, mode=copy_mode, trim=True, collation=collation)
         saved_checksums = saved_fileset.hash_files(crypto=hashlib.md5, relative_to=resource_dir)
         manifest = {"datatype": self.fileset.mime_like, "checksums": saved_checksums}

--- a/xnat_ingest/model/resource.py
+++ b/xnat_ingest/model/resource.py
@@ -77,7 +77,7 @@ class ImagingResource:
         self,
         dest_dir: Path,
         copy_mode: FileSet.CopyMode = FileSet.CopyMode.copy,
-        collation: FileSet.CopyCollation = FileSet.CopyCollation.any,
+        collate_datatypes: tuple[ty.Type[FileSet], ...] = (),
         calculate_checksums: bool = True,
         overwrite: bool | None = None,
     ) -> Self:
@@ -142,6 +142,11 @@ class ImagingResource:
                     "incomplete, overwriting"
                 )
                 shutil.rmtree(resource_dir)
+        collation = (
+            FileSet.CopyCollation.siblings
+            if collate_datatypes and isinstance(self.fileset, collate_datatypes)
+            else FileSet.CopyCollation.any
+        )
         saved_fileset = self.fileset.copy(resource_dir, mode=copy_mode, trim=True, collation=collation)
         saved_checksums = saved_fileset.hash_files(crypto=hashlib.md5, relative_to=resource_dir)
         manifest = {"datatype": self.fileset.mime_like, "checksums": saved_checksums}

--- a/xnat_ingest/model/scan.py
+++ b/xnat_ingest/model/scan.py
@@ -70,13 +70,14 @@ class ImagingScan:
         self,
         dest_dir: Path,
         copy_mode: FileSet.CopyMode = FileSet.CopyMode.hardlink_or_copy,
+        collation: FileSet.CopyCollation = FileSet.CopyCollation.any,
     ) -> Self:
         # Ensure scan type is a valid directory name
         saved = self.new_empty()
         scan_dir = dest_dir / f"{self.id}.{self.type}"
         scan_dir.mkdir(parents=True, exist_ok=True)
         for resource in self.resources.values():
-            saved_resource = resource.save(scan_dir, copy_mode=copy_mode)
+            saved_resource = resource.save(scan_dir, copy_mode=copy_mode, collation=collation)
             saved_resource.scan = saved
             saved.resources[saved_resource.name] = saved_resource
         return saved

--- a/xnat_ingest/model/scan.py
+++ b/xnat_ingest/model/scan.py
@@ -70,14 +70,14 @@ class ImagingScan:
         self,
         dest_dir: Path,
         copy_mode: FileSet.CopyMode = FileSet.CopyMode.hardlink_or_copy,
-        collation: FileSet.CopyCollation = FileSet.CopyCollation.any,
+        collate_datatypes: tuple[ty.Type[FileSet], ...] = (),
     ) -> Self:
         # Ensure scan type is a valid directory name
         saved = self.new_empty()
         scan_dir = dest_dir / f"{self.id}.{self.type}"
         scan_dir.mkdir(parents=True, exist_ok=True)
         for resource in self.resources.values():
-            saved_resource = resource.save(scan_dir, copy_mode=copy_mode, collation=collation)
+            saved_resource = resource.save(scan_dir, copy_mode=copy_mode, collate_datatypes=collate_datatypes)
             saved_resource.scan = saved
             saved.resources[saved_resource.name] = saved_resource
         return saved

--- a/xnat_ingest/model/scan.py
+++ b/xnat_ingest/model/scan.py
@@ -70,14 +70,14 @@ class ImagingScan:
         self,
         dest_dir: Path,
         copy_mode: FileSet.CopyMode = FileSet.CopyMode.hardlink_or_copy,
-        collate_datatypes: tuple[ty.Type[FileSet], ...] = (),
+        collation_map: dict[ty.Type[FileSet], FileSet.CopyCollation] | None = None,
     ) -> Self:
         # Ensure scan type is a valid directory name
         saved = self.new_empty()
         scan_dir = dest_dir / f"{self.id}.{self.type}"
         scan_dir.mkdir(parents=True, exist_ok=True)
         for resource in self.resources.values():
-            saved_resource = resource.save(scan_dir, copy_mode=copy_mode, collate_datatypes=collate_datatypes)
+            saved_resource = resource.save(scan_dir, copy_mode=copy_mode, collation_map=collation_map)
             saved_resource.scan = saved
             saved.resources[saved_resource.name] = saved_resource
         return saved

--- a/xnat_ingest/model/session.py
+++ b/xnat_ingest/model/session.py
@@ -847,7 +847,7 @@ class ImagingSession:
         dest_dir: Path,
         available_projects: ty.Optional[ty.List[str]] = None,
         copy_mode: FileSet.CopyMode = FileSet.CopyMode.hardlink_or_copy,
-        collate_datatypes: tuple[ty.Type[FileSet], ...] = (),
+        collation_map: dict[ty.Type[FileSet], FileSet.CopyCollation] | None = None,
         save_metadata: bool = True,
     ) -> tuple[Self, Path]:
         r"""Saves the session to a directory. The session will be saved to a directory
@@ -890,7 +890,7 @@ class ImagingSession:
         session_dir = dest_dir / session_dirname
         session_dir.mkdir(parents=True, exist_ok=True)
         for scan in tqdm(self.scans.values(), f"Staging sessions to {session_dir}"):
-            saved_scan = scan.save(session_dir, copy_mode=copy_mode, collate_datatypes=collate_datatypes)
+            saved_scan = scan.save(session_dir, copy_mode=copy_mode, collation_map=collation_map)
             saved_scan.session = saved
             saved.scans[saved_scan.id] = saved_scan
         if save_metadata:

--- a/xnat_ingest/model/session.py
+++ b/xnat_ingest/model/session.py
@@ -847,6 +847,7 @@ class ImagingSession:
         dest_dir: Path,
         available_projects: ty.Optional[ty.List[str]] = None,
         copy_mode: FileSet.CopyMode = FileSet.CopyMode.hardlink_or_copy,
+        collation: FileSet.CopyCollation = FileSet.CopyCollation.any,
         save_metadata: bool = True,
     ) -> tuple[Self, Path]:
         r"""Saves the session to a directory. The session will be saved to a directory
@@ -889,7 +890,7 @@ class ImagingSession:
         session_dir = dest_dir / session_dirname
         session_dir.mkdir(parents=True, exist_ok=True)
         for scan in tqdm(self.scans.values(), f"Staging sessions to {session_dir}"):
-            saved_scan = scan.save(session_dir, copy_mode=copy_mode)
+            saved_scan = scan.save(session_dir, copy_mode=copy_mode, collation=collation)
             saved_scan.session = saved
             saved.scans[saved_scan.id] = saved_scan
         if save_metadata:

--- a/xnat_ingest/model/session.py
+++ b/xnat_ingest/model/session.py
@@ -847,7 +847,7 @@ class ImagingSession:
         dest_dir: Path,
         available_projects: ty.Optional[ty.List[str]] = None,
         copy_mode: FileSet.CopyMode = FileSet.CopyMode.hardlink_or_copy,
-        collation: FileSet.CopyCollation = FileSet.CopyCollation.any,
+        collate_datatypes: tuple[ty.Type[FileSet], ...] = (),
         save_metadata: bool = True,
     ) -> tuple[Self, Path]:
         r"""Saves the session to a directory. The session will be saved to a directory
@@ -890,7 +890,7 @@ class ImagingSession:
         session_dir = dest_dir / session_dirname
         session_dir.mkdir(parents=True, exist_ok=True)
         for scan in tqdm(self.scans.values(), f"Staging sessions to {session_dir}"):
-            saved_scan = scan.save(session_dir, copy_mode=copy_mode, collation=collation)
+            saved_scan = scan.save(session_dir, copy_mode=copy_mode, collate_datatypes=collate_datatypes)
             saved_scan.session = saved
             saved.scans[saved_scan.id] = saved_scan
         if save_metadata:


### PR DESCRIPTION
When you sort files into the resource directory, they keep whatever directory structure they had at the source. Orthanc stores files like this

DICOM/
    92/
      5a/
        4a6a5151... (DICOM file)

This caused problems when trying to upload to XNAT, as `load()` used `iterdir()` to get the files, which only looks at the top level of the directory and hence only sees `92/`. So when it checked the manifest keys against what it found in the directory, 92/5a/4a6a5151... wasn't in `92/` hence IncompleteCheckumsException.

The checksums part has also changed to compute them from the saved files, instead of from the source fileset before copying. 

The new `collate` flag will let us essentially dump all the DICOMs under `DICOM/` and avoid the nested directories (particularly a problem with Orthanc). This does mean the sort command for Orthanc workflows is slightly different, not sure if that is a problem.