### PR TITLE
session level resource upload

### DIFF
--- a/xnat_ingest/helpers/remotes.py
+++ b/xnat_ingest/helpers/remotes.py
@@ -209,7 +209,7 @@ def iterate_s3_sessions(
     )
     bucket_name, prefix = bucket_path[5:].split("/", 1)
     bucket = s3.Bucket(bucket_name)
-    if not prefix.endswith("/"):
+    if prefix and not prefix.endswith("/"):
         prefix += "/"
     all_objects = bucket.objects.filter(Prefix=prefix)
     session_objs = defaultdict(list)

--- a/xnat_ingest/helpers/remotes.py
+++ b/xnat_ingest/helpers/remotes.py
@@ -91,6 +91,8 @@ class SessionListing(metaclass=abc.ABCMeta):
         for xscan in xsession.scans.values():
             for xresource in xscan.resources.values():
                 resource_paths.add(f"{xscan.id}.{xscan.type}/{xresource.label}")
+        for xresource in xsession.resources.values():
+            resource_paths.add(xresource.label)
         return resource_paths.issuperset(self.resource_paths)
 
 
@@ -106,6 +108,10 @@ class LocalSessionListing(SessionListing):
     @property
     def resource_paths(self) -> set[str]:
         paths = {str(p.relative_to(self.fspath)) for p in self.fspath.glob("*/*")}
+        # session resources: top-level dirs with no "." in name
+        for item in self.fspath.iterdir():
+            if item.is_dir() and "." not in item.name:
+                paths.add(item.name)
         paths.discard(ImagingSession.METADATA_FNAME)
         return paths
 
@@ -146,7 +152,18 @@ class S3SessionListing(SessionListing):
 
     @property
     def resource_paths(self) -> set[str]:
-        paths = {"/".join(o[0][:2]) for o in self.objects}
+        paths = set()
+        for path_parts, _ in self.objects:
+            if not path_parts:
+                continue
+            first = path_parts[0]
+            if "." in first:
+                # scan resource: <scan_id>.<scan_type>/<resource_name>
+                if len(path_parts) >= 2:
+                    paths.add(f"{first}/{path_parts[1]}")
+            else:
+                # session resource: <resource_name> (no dot in dir name)
+                paths.add(first)
         paths.discard(ImagingSession.METADATA_FNAME)
         return paths
 
@@ -346,6 +363,32 @@ def get_xnat_resource(resource: ImagingResource, xsession: ty.Any) -> ty.Any:
     """
     xclasses = xsession.xnat_session.classes
     resource_name = resource.name
+
+    if resource.scan is None:
+        try:
+            xresource = xsession.resources[resource_name]
+        except KeyError:
+            pass
+        else:
+            checksums = get_xnat_checksums(xresource)
+            if checksums != resource.checksums:
+                difference = {
+                    k: (v, resource.checksums[k])
+                    for k, v in checksums.items()
+                    if v != resource.checksums[k]
+                }
+                logger.error(
+                    "'%s' session resource already exists on XNAT. Please delete on XNAT to overwrite:\n%s",
+                    resource_name,
+                    pprint.pformat(difference),
+                )
+            return None
+        logger.debug("Creating session resource %s in %s", resource_name, xsession.label)
+        uri = f"{xsession.uri}/resources/{resource_name}"
+        xsession.xnat_session.put(uri)
+        xsession.clearcache()
+        return xsession.xnat_session.create_object(uri)
+
     try:
         xscan = xsession.scans[resource.scan.id]
     except KeyError:

--- a/xnat_ingest/model/resource.py
+++ b/xnat_ingest/model/resource.py
@@ -60,6 +60,12 @@ class ImagingResource:
         return self.fileset.mime_like
 
     def __lt__(self, other: Self) -> bool:
+        if self.scan is None and other.scan is None:
+            return self.name < other.name
+        if self.scan is None:
+            return True  # session resources sort before scan resources
+        if other.scan is None:
+            return False
         try:
             scan_id = int(self.scan.id)
         except ValueError:
@@ -215,6 +221,8 @@ class ImagingResource:
 
     @property
     def path(self) -> str:
+        if self.scan is None:
+            return self.name
         return self.scan.path + ":" + self.name
 
     MANIFEST_FNAME = "MANIFEST.json"

--- a/xnat_ingest/model/session.py
+++ b/xnat_ingest/model/session.py
@@ -67,6 +67,7 @@ class ImagingSession:
         converter=scans_converter,
         validator=attrs.validators.instance_of(dict),
     )
+    session_resources: ty.Dict[str, ImagingResource] = attrs.field(factory=dict)
     run_uid: ty.Optional[str] = attrs.field(default=None)
     _metadata: dict[str, ty.Any] | None = attrs.field(
         default=None, eq=False, repr=False, init=False
@@ -136,7 +137,9 @@ class ImagingSession:
 
     @property
     def resources(self) -> ty.List[ImagingResource]:
-        return [r for p in self.scans.values() for r in p.resources.values()]
+        return list(self.session_resources.values()) + [
+            r for p in self.scans.values() for r in p.resources.values()
+        ]
 
     @property
     def primary_resources(self) -> ty.List[ImagingResource]:
@@ -201,6 +204,10 @@ class ImagingSession:
                     raise ValueError(
                         f"{mime_like!r} does not correspond to a file format ({fileformat})"
                     )
+            for resource in self.session_resources.values():
+                if isinstance(resource.fileset, fileformat):
+                    uploaded.add((None, resource.name))
+                    yield resource
             for scan in self.scans.values():
                 for resource in scan.resources.values():
                     if isinstance(resource.fileset, fileformat):
@@ -750,6 +757,35 @@ class ImagingSession:
                 )
         scan.resources[resource_name] = resource
 
+    def add_session_resource(
+        self,
+        resource_name: str,
+        fileset: FileSet,
+        overwrite: bool = False,
+    ) -> None:
+        """Adds a session-level resource
+
+        Parameters
+        ----------
+        resource_name : str
+            the name of the resource
+        fileset : FileSet
+            the fileset to add as the resource
+        overwrite : bool
+            whether to overwrite an existing resource with the same name
+        """
+        resource = ImagingResource(name=resource_name, fileset=fileset)
+        if resource_name in self.session_resources:
+            existing = self.session_resources[resource_name]
+            if resource.checksums == existing.checksums:
+                return
+            if not overwrite:
+                raise KeyError(
+                    f"Session resource '{resource_name}' already exists in {self.name}. "
+                    "Use 'overwrite=True' to overwrite."
+                )
+        self.session_resources[resource_name] = resource
+
     @classmethod
     def from_metadata_yaml(cls, yaml_path: Path) -> Self:
         """Creates a metadata-only session from a __metadata__/ YAML file.
@@ -828,15 +864,26 @@ class ImagingSession:
             visit_id=visit_id,
             run_uid=run_uid,
         )
-        for scan_dir in session_dir.iterdir():
-            if scan_dir.is_dir():
+        for item in session_dir.iterdir():
+            if not item.is_dir():
+                continue
+            if "." in item.name:
+                # scan directory: <scan_id>.<scan_type>
                 scan = ImagingScan.load(
-                    scan_dir,
+                    item,
                     require_manifest=require_manifest,
                     check_checksums=check_checksums,
                 )
                 scan.session = session
                 session.scans[scan.id] = scan
+            else:
+                # session resource directory: <resource_name> (no dot)
+                resource = ImagingResource.load(
+                    item,
+                    require_manifest=require_manifest,
+                    check_checksums=check_checksums,
+                )
+                session.session_resources[resource.name] = resource
         metadata_path = session_dir / cls.METADATA_FNAME
         if metadata_path.exists():
             session._metadata = Yaml(metadata_path).load()
@@ -893,6 +940,9 @@ class ImagingSession:
             saved_scan = scan.save(session_dir, copy_mode=copy_mode, collation_map=collation_map)
             saved_scan.session = saved
             saved.scans[saved_scan.id] = saved_scan
+        for resource in self.session_resources.values():
+            saved_resource = resource.save(session_dir, copy_mode=copy_mode)
+            saved.session_resources[saved_resource.name] = saved_resource
         if save_metadata:
             metadata_path = (
                 session_dir / self.METADATA_FNAME

--- a/xnat_ingest/model/tests/test_session.py
+++ b/xnat_ingest/model/tests/test_session.py
@@ -491,6 +491,28 @@ def test_associate_files_metadata_only(tmp_path: Path) -> None:
     }
 
 
+def test_session_resource_save_roundtrip(tmp_path: Path) -> None:
+    """Session-level resources (no-dot dirs) survive a save/load roundtrip."""
+    pdf = File.sample(seed=42)
+
+    session = ImagingSession(
+        project_id="PROJ",
+        subject_id="SUBJ",
+        visit_id="VIS",
+        scans=[],
+    )
+    session.add_session_resource("radiology-doc-report", pdf)
+
+    saved, _ = session.save(tmp_path)
+    assert "radiology-doc-report" in saved.session_resources
+
+    session_dir = tmp_path.joinpath(*session.staging_relpath)
+    reloaded = ImagingSession.load(session_dir)
+
+    assert "radiology-doc-report" in reloaded.session_resources
+    assert reloaded.session_resources["radiology-doc-report"].checksums == saved.session_resources["radiology-doc-report"].checksums
+
+
 def test_id_escape(tmp_path: Path) -> None:
     raw_data_dir = tmp_path / "raw"
     raw_data_dir.mkdir()


### PR DESCRIPTION
Added a feature so that we can upload resources to an XNAT session without them having to belong to a scan. If the resource has no scan, they are session level and `load()` detects subduers without an `.` in their name as session resources.

Small fix to S3 bucket prefix, and added a test for session resource loading.

Will not close the issue until code is running on the upload container.