### PR TITLE
discord notifications for logging

### DIFF
--- a/xnat_ingest/helpers/logging.py
+++ b/xnat_ingest/helpers/logging.py
@@ -1,6 +1,5 @@
 """Helper functions and classes for logging"""
 
-import asyncio
 import logging
 import sys
 import typing as ty
@@ -64,7 +63,7 @@ class DiscordHandler(logging.Handler):
     def __init__(self, webhook_url: str):
         super().__init__()
         self.webhook_url = webhook_url
-        self.client = discord.Webhook.from_url(webhook_url)
+        self.client = discord.SyncWebhook.from_url(webhook_url)
 
     def emit(self, record: logging.LogRecord) -> None:
-        asyncio.run(self.client.send(record.msg))
+        self.client.send(self.format(record))


### PR DESCRIPTION
Removed async to sync for the discord logging, can be set up with env vars or in the xnat-ingest command itself. Ran with a sort command and worked well:

<img width="885" height="273" alt="image" src="https://github.com/user-attachments/assets/766f1bf1-69bb-4f79-b4c8-9161337bd2a2" />