### PR TITLE
fix(cli): add missing recursive/require-manifest options to deidentify CLI

### DIFF
--- a/xnat_ingest/api/deidentify_.py
+++ b/xnat_ingest/api/deidentify_.py
@@ -18,11 +18,19 @@ def deidentify(
     copy_mode: FileSet.CopyMode = FileSet.CopyMode.copy,
     require_manifest: bool = True,
     delete: bool = False,
+    recursive: bool = False,
 ) -> list[str]:
 
-    sessions: list[LocalSessionListing] = [
-        LocalSessionListing(p) for p in Path(input_dir).iterdir()
-    ]
+    if recursive:
+        sessions = [
+            LocalSessionListing(p)
+            for p in Path(input_dir).rglob("*")
+            if p.is_dir()
+        ]
+    else:
+        sessions = [
+            LocalSessionListing(p) for p in Path(input_dir).iterdir()
+        ]
     num_sessions = len(sessions)
     logger.info(
         "Found %d sessions in staging directory to stage'%s'",

--- a/xnat_ingest/cli/deidentify.py
+++ b/xnat_ingest/cli/deidentify.py
@@ -110,6 +110,13 @@ are uploaded to XNAT
     ),
 )
 @click.option(
+    "--require-manifest/--dont-require-manifest",
+    default=True,
+    envvar="XINGEST_REQUIRE_MANIFEST",
+    help=("Whether to require manifest files in the staged resources or not"),
+    type=bool,
+)
+@click.option(
     "--recursive/--not-recursive",
     type=bool,
     default=False,
@@ -127,6 +134,7 @@ def deidentify_cli(
     loop: int,
     avoid_clashes: bool,
     delete: bool,
+    recursive: bool,
 ) -> None:
 
     if raise_errors and loop >= 0:
@@ -152,6 +160,7 @@ def deidentify_cli(
             copy_mode=copy_mode,
             require_manifest=require_manifest,
             delete=delete,
+            recursive=recursive,
         )
         if errors:
             logger.error(


### PR DESCRIPTION
Fixes #78.

The `deidentify_cli` function signature was missing the `recursive` parameter (decorator present but not in signature), and `require_manifest` was in the signature but had no decorator. Click would have rejected the call as soon as either was used.

- Add `--require-manifest/--dont-require-manifest` decorator matching `upload_cli`.
- Add `recursive: bool` to the signature and thread it through to the underlying `deidentify()` API.
- When `recursive=True`, walk `input_dir` with `rglob('*')` instead of `iterdir()`.

No new dependencies.