### PR TITLE
Orthanc API sorting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "pydicom >=2.3.1",
     "tqdm >=4.64.1",
     "boto3",
+    "requests",
     "natsort",
     "paramiko",
     "xnat",

--- a/xnat_ingest/api/sort_.py
+++ b/xnat_ingest/api/sort_.py
@@ -40,6 +40,11 @@ def sort(
     recursive: bool = False,
     xnat_login: XnatLogin | None = None,
     save_metadata: bool | Path = False,
+    orthanc_url: str | None = None,
+    orthanc_user: str | None = None,
+    orthanc_password: str | None = None,
+    orthanc_storage_dir: Path | None = None,
+    orthanc_label: str = "xnat-sorted",
 ) -> list[str]:
     """Sorts the input files into sessions and stages them into the staging directory.
 
@@ -125,6 +130,28 @@ def sort(
     if save_metadata:
         metadata_dir = output_dir / ImagingSession.METADATA_DIR
         metadata_dir.mkdir(parents=True, exist_ok=True)
+
+    if orthanc_url:
+        if orthanc_storage_dir is None:
+            raise ValueError(
+                "--orthanc-storage-dir must be provided when using --orthanc-url"
+            )
+        ImagingSession.from_orthanc(
+            orthanc_url=orthanc_url,
+            output_dir=output_dir,
+            orthanc_storage_dir=orthanc_storage_dir,
+            project_field=project_field,
+            subject_field=subject_field,
+            visit_field=visit_field,
+            scan_id_field=scan_id_field,
+            scan_desc_field=scan_desc_field,
+            project_id=project_id,
+            orthanc_user=orthanc_user,
+            orthanc_password=orthanc_password,
+            orthanc_label=orthanc_label,
+            available_projects=project_list,
+        )
+        return errors
 
     sessions = ImagingSession.from_paths(
         files_path=input_paths,

--- a/xnat_ingest/api/sort_.py
+++ b/xnat_ingest/api/sort_.py
@@ -10,7 +10,7 @@ from filelock import SoftFileLock
 from frametree.xnat import Xnat
 from tqdm import tqdm
 
-from ..helpers.arg_types import FieldSpec, XnatLogin
+from ..helpers.arg_types import FieldSpec, OrthancLogin, XnatLogin
 from ..helpers.logging import logger
 from ..model.session import ImagingSession
 
@@ -40,10 +40,7 @@ def sort(
     recursive: bool = False,
     xnat_login: XnatLogin | None = None,
     save_metadata: bool | Path = False,
-    orthanc_url: str | None = None,
-    orthanc_user: str | None = None,
-    orthanc_password: str | None = None,
-    orthanc_storage_dir: Path | None = None,
+    orthanc: OrthancLogin | None = None,
     orthanc_label: str = "xnat-sorted",
 ) -> list[str]:
     """Sorts the input files into sessions and stages them into the staging directory.
@@ -131,23 +128,19 @@ def sort(
         metadata_dir = output_dir / ImagingSession.METADATA_DIR
         metadata_dir.mkdir(parents=True, exist_ok=True)
 
-    if orthanc_url:
-        if orthanc_storage_dir is None:
-            raise ValueError(
-                "--orthanc-storage-dir must be provided when using --orthanc-url"
-            )
+    if orthanc:
         ImagingSession.from_orthanc(
-            orthanc_url=orthanc_url,
+            orthanc_url=orthanc.url,
             output_dir=output_dir,
-            orthanc_storage_dir=orthanc_storage_dir,
+            orthanc_storage_dir=orthanc.storage_dir,
             project_field=project_field,
             subject_field=subject_field,
             visit_field=visit_field,
             scan_id_field=scan_id_field,
             scan_desc_field=scan_desc_field,
             project_id=project_id,
-            orthanc_user=orthanc_user,
-            orthanc_password=orthanc_password,
+            orthanc_user=orthanc.user,
+            orthanc_password=orthanc.password,
             orthanc_label=orthanc_label,
             available_projects=project_list,
         )

--- a/xnat_ingest/cli/sort.py
+++ b/xnat_ingest/cli/sort.py
@@ -249,6 +249,52 @@ are uploaded to XNAT
         "Collation level is one of 'any', 'siblings', or 'adjacent' (default 'siblings'). "
     ),
 )
+@click.option(
+    "--orthanc-url",
+    type=str,
+    default=None,
+    envvar="XINGEST_ORTHANC_URL",
+    help=(
+        "Base URL of an Orthanc REST API to sort from (e.g. http://orthanc:8042). "
+        "(XINGEST_ORTHANC_URL env. var)"
+    ),
+)
+@click.option(
+    "--orthanc-user",
+    type=str,
+    default=None,
+    envvar="XINGEST_ORTHANC_USER",
+    help="Orthanc auth username (XINGEST_ORTHANC_USER env. var)",
+)
+@click.option(
+    "--orthanc-password",
+    type=str,
+    default=None,
+    envvar="XINGEST_ORTHANC_PASSWORD",
+    help="Orthanc auth password (XINGEST_ORTHANC_PASSWORD env. var)",
+)
+@click.option(
+    "--orthanc-storage-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    envvar="XINGEST_ORTHANC_STORAGE_DIR",
+    help=(
+        "Path to Orthanc's StorageDirectory as mounted in pod. DICOM files are "
+        "hardlinked from here directly to the staging directory"
+        "(XINGEST_ORTHANC_STORAGE_DIR env. var)"
+    ),
+)
+@click.option(
+    "--orthanc-label",
+    type=str,
+    default="xnat-sorted",
+    envvar="XINGEST_ORTHANC_LABEL",
+    help=(
+        "Label applied to Orthanc studies after staging to prevent re-processing. "
+        "Can be removed via the Orthanc UI "
+        "(XINGEST_ORTHANC_LABEL env. var)"
+    ),
+)
 def sort_cli(
     input_paths: list[str],
     staging_dir: Path,
@@ -273,6 +319,11 @@ def sort_cli(
     copy_mode: FileSet.CopyMode,
     save_metadata: bool,
     collate_resources: tuple[CollationSpec, ...],
+    orthanc_url: str | None,
+    orthanc_user: str | None,
+    orthanc_password: str | None,
+    orthanc_storage_dir: Path | None,
+    orthanc_label: str,
 ) -> None:
 
     if raise_errors and loop >= 0:
@@ -315,6 +366,11 @@ def sort_cli(
             xnat_login=xnat_login,
             save_metadata=save_metadata,
             collation_map={cs.datatype: cs.collation_level for cs in collate_resources},
+            orthanc_url=orthanc_url,
+            orthanc_user=orthanc_user,
+            orthanc_password=orthanc_password,
+            orthanc_storage_dir=orthanc_storage_dir,
+            orthanc_label=orthanc_label,
         )
         if errors:
             logger.error(

--- a/xnat_ingest/cli/sort.py
+++ b/xnat_ingest/cli/sort.py
@@ -16,6 +16,7 @@ from ..helpers.arg_types import (
     FieldSpec,
     LoggerConfig,
     MimeType,
+    OrthancLogin,
     XnatLogin,
 )
 from ..helpers.logging import logger, set_logger_handling
@@ -250,38 +251,17 @@ are uploaded to XNAT
     ),
 )
 @click.option(
-    "--orthanc-url",
-    type=str,
+    "--orthanc",
+    "orthanc",
+    nargs=4,
+    type=OrthancLogin.cli_type,
     default=None,
-    envvar="XINGEST_ORTHANC_URL",
+    metavar="<url> <user> <password> <storage-dir>",
+    envvar="XINGEST_ORTHANC",
     help=(
-        "Base URL of an Orthanc REST API to sort from (e.g. http://orthanc:8042). "
-        "(XINGEST_ORTHANC_URL env. var)"
-    ),
-)
-@click.option(
-    "--orthanc-user",
-    type=str,
-    default=None,
-    envvar="XINGEST_ORTHANC_USER",
-    help="Orthanc auth username (XINGEST_ORTHANC_USER env. var)",
-)
-@click.option(
-    "--orthanc-password",
-    type=str,
-    default=None,
-    envvar="XINGEST_ORTHANC_PASSWORD",
-    help="Orthanc auth password (XINGEST_ORTHANC_PASSWORD env. var)",
-)
-@click.option(
-    "--orthanc-storage-dir",
-    type=click.Path(path_type=Path),
-    default=None,
-    envvar="XINGEST_ORTHANC_STORAGE_DIR",
-    help=(
-        "Path to Orthanc's StorageDirectory as mounted in pod. DICOM files are "
-        "hardlinked from here directly to the staging directory"
-        "(XINGEST_ORTHANC_STORAGE_DIR env. var)"
+        "Orthanc connection details: base URL, username, password, and path to Orthanc's "
+        "StorageDirectory as mounted in pod. DICOM files are hardlinked from the storage "
+        "directory directly to the staging directory. (XINGEST_ORTHANC env. var)"
     ),
 )
 @click.option(
@@ -319,10 +299,7 @@ def sort_cli(
     copy_mode: FileSet.CopyMode,
     save_metadata: bool,
     collate_resources: tuple[CollationSpec, ...],
-    orthanc_url: str | None,
-    orthanc_user: str | None,
-    orthanc_password: str | None,
-    orthanc_storage_dir: Path | None,
+    orthanc: OrthancLogin | None,
     orthanc_label: str,
 ) -> None:
 
@@ -366,10 +343,7 @@ def sort_cli(
             xnat_login=xnat_login,
             save_metadata=save_metadata,
             collation_map={cs.datatype: cs.collation_level for cs in collate_resources},
-            orthanc_url=orthanc_url,
-            orthanc_user=orthanc_user,
-            orthanc_password=orthanc_password,
-            orthanc_storage_dir=orthanc_storage_dir,
+            orthanc=orthanc,
             orthanc_label=orthanc_label,
         )
         if errors:

--- a/xnat_ingest/helpers/arg_types.py
+++ b/xnat_ingest/helpers/arg_types.py
@@ -6,6 +6,7 @@ import re
 import string
 import typing as ty
 from collections import Counter
+from pathlib import Path
 
 import attrs
 import click.types
@@ -159,6 +160,15 @@ class XnatLogin(CliTyped):
     host: str
     user: str
     password: str
+
+
+@attrs.define
+class OrthancLogin(CliTyped):
+
+    url: str
+    user: str
+    password: str
+    storage_dir: Path = attrs.field(converter=Path)
 
 
 @attrs.define

--- a/xnat_ingest/model/session.py
+++ b/xnat_ingest/model/session.py
@@ -1,8 +1,11 @@
 import hashlib
 import inspect
+import json
 import logging
+import os
 import platform
 import re
+import requests
 import typing as ty
 from collections import Counter, defaultdict
 from datetime import datetime
@@ -529,6 +532,175 @@ class ImagingSession:
                 )
             )
         return list(sessions.values())
+
+    @classmethod
+    def from_orthanc(
+        cls,
+        orthanc_url: str,
+        output_dir: Path,
+        orthanc_storage_dir: Path,
+        project_field: list[FieldSpec],
+        subject_field: list[FieldSpec],
+        visit_field: list[FieldSpec],
+        scan_id_field: list[FieldSpec],
+        scan_desc_field: list[FieldSpec],
+        project_id: str | None = None,
+        orthanc_user: str | None = None,
+        orthanc_password: str | None = None,
+        orthanc_label: str = "xnat-sorted",
+        available_projects: list[str] | None = None,
+    ) -> ty.List["ImagingSession"]:
+        """Stage DICOM studies from Orthanc directly into output_dir using hardlinks.
+        Requires orthanc_storage_dir and output_dir to be on the same filesystem.
+
+        Parameters
+        ----------
+        orthanc_url : str
+            Base URL of the Orthanc REST API, e.g. 'http://orthanc:8042'
+        output_dir : Path
+            Staging directory. Hardlinks land here directly, must be on the same
+            filesystem as orthanc_storage_dir.
+        orthanc_storage_dir : Path
+            Orthanc's StorageDirectory as mounted.
+        project_field, subject_field, visit_field : list[FieldSpec]
+            Field specs to extract XNAT IDs from Orthanc's indexed tags.
+        scan_id_field, scan_desc_field : list[FieldSpec]
+            Field specs to extract scan naming from series-level tags.
+        project_id : str, optional
+            Override project ID for all studies.
+        orthanc_user, orthanc_password : str, optional
+            Orthanc basic auth credentials.
+        orthanc_label : str, optional
+            Label applied after staging to prevent re-processing, by default 'xnat-sorted'.
+            Remove via the Orthanc UI to re-sort a study.
+        available_projects : list[str], optional
+            Valid XNAT project IDs; unrecognised projects get an INVALID_ prefix.
+
+        Returns
+        -------
+        list[ImagingSession]
+            Staged sessions loaded from output_dir.
+        """
+        auth = (orthanc_user, orthanc_password) if orthanc_user else None
+
+        def get_json(path: str) -> ty.Any:
+            resp = requests.get(f"{orthanc_url}{path}", auth=auth)
+            resp.raise_for_status()
+            return resp.json()
+
+        class _TagsAdapter:
+            """Adapter so FieldSpec.get_value() can read an Orthanc tag dict."""
+            def __init__(self, tags: dict) -> None:
+                self.metadata = tags
+
+        def eval_field(specs: list[FieldSpec], tags: dict, escape: bool = False) -> str:
+            """Return the first FieldSpec value that resolves, or 'UNKNOWN'.
+
+            Parameters
+            ----------
+            escape : bool
+                If True, replace non-alphanumeric/underscore characters with '_'
+            """
+            adapter = _TagsAdapter(tags)
+            for spec in specs:
+                try:
+                    val = spec.get_value(adapter)
+                    if val:
+                        if escape:
+                            val = FieldSpec.xnat_id_escape_re.sub("_", val)
+                        return val
+                except Exception:
+                    continue
+            return "UNKNOWN"
+
+        resp = requests.post(
+            f"{orthanc_url}/tools/find",
+            auth=auth,
+            json={
+                "Level": "Study",
+                "Query": {},
+                "Labels": [orthanc_label],
+                "LabelsConstraint": "None",
+            },
+        )
+        resp.raise_for_status()
+        study_ids = resp.json()
+        logger.info(
+            "Found %d unstaged studies in Orthanc at '%s'", len(study_ids), orthanc_url
+        )
+
+        staged: list[ImagingSession] = []
+        for study_id in tqdm(study_ids, "Staging studies from Orthanc"):
+            study = get_json(f"/studies/{study_id}")
+            study_tags = {**study["MainDicomTags"], **study["PatientMainDicomTags"]}
+
+            proj = project_id if project_id is not None else eval_field(project_field, study_tags, escape=True)
+            if available_projects is not None and proj not in available_projects:
+                proj = "INVALID_UNRECOGNISED_" + proj
+            subj = eval_field(subject_field, study_tags, escape=True)
+            visit = eval_field(visit_field, study_tags, escape=True)
+
+            session_dir = output_dir / f"{proj}.{subj}.{visit}"
+            session_dir.mkdir(parents=True, exist_ok=True)
+
+            modalities: set[str] = set()
+            for series_id in study["Series"]:
+                series = get_json(f"/series/{series_id}")
+                if modality := series["MainDicomTags"].get("Modality"):
+                    modalities.add(modality)
+                all_tags = {**study_tags, **series["MainDicomTags"]}
+                scan_id = eval_field(scan_id_field, all_tags)
+                scan_type = eval_field(scan_desc_field, all_tags)
+
+                resource_dir = session_dir / f"{scan_id}.{scan_type}" / "DICOM"
+                resource_dir.mkdir(parents=True, exist_ok=True)
+
+                instances = get_json(f"/series/{series_id}/instances")
+                checksums: dict[str, str] = {}
+                for instance in instances:
+                    instance_id = instance["ID"]
+                    sop_uid = instance["MainDicomTags"].get("SOPInstanceUID", instance_id)
+                    fname = f"{sop_uid}.dcm"
+                    dest_path = resource_dir / fname
+                    if dest_path.exists():
+                        continue
+                    attachment = get_json(
+                        f"/instances/{instance_id}/attachments/dicom/info"
+                    )
+                    if attachment["CompressedSize"] != attachment["UncompressedSize"]:
+                        raise ValueError(
+                            f"Instance '{instance_id}' in series '{series_id}' is stored "
+                            "compressed in Orthanc — disable StorageCompression in the "
+                            "Orthanc config to use hardlink sorting."
+                        )
+                    uuid = attachment["Uuid"]
+                    src_path = Path(orthanc_storage_dir) / uuid[0:2] / uuid[2:4] / uuid
+                    os.link(src_path, dest_path)
+                    checksums[fname] = attachment["UncompressedMD5"]
+
+                manifest = {"datatype": "medimage/dicom-series", "checksums": checksums}
+                with open(resource_dir / ImagingResource.MANIFEST_FNAME, "w") as f:
+                    json.dump(manifest, f, indent=2)
+
+            metadata_path = session_dir / cls.METADATA_FNAME
+            if not metadata_path.exists():
+                if modalities:
+                    study_tags["Modality"] = (
+                        next(iter(modalities)) if len(modalities) == 1 else list(modalities)
+                    )
+                with open(metadata_path, "w") as f:
+                    yaml.dump(study_tags, f, indent=4)
+
+            requests.put(
+                f"{orthanc_url}/studies/{study_id}/labels/{orthanc_label}", auth=auth
+            ).raise_for_status()
+            logger.info(
+                "Staged and labelled study '%s' -> '%s'", study_id, session_dir.name
+            )
+
+            staged.append(cls.load(session_dir))
+
+        return staged
 
     def deidentify(
         self,


### PR DESCRIPTION
Adds `ImagingSession.from_orthanc()` and wires it through the sort API and CLI, allowing xnat-ingest sort to pull studies directly from an Orthanc DICOM server instead of scanning a filesystem.

- All XNAT IDs (project, subject, visit, scan ID, scan description) are read from Orthanc's REST API index
- Project/subject/visit IDs are sanitised using the same FieldSpec.xnat_id_escape_re pattern as the normal sort path, replacing characters like ^ that XNAT rejects
- After each study is staged, PUT /studies/{id}/labels/xnat-sorted marks it so it is skipped on the next run

Runs with new CLI options: 

```
xnat-ingest sort /data/sorted \
    --orthanc-url http://orthanc:8042 \
    --orthanc-storage-dir /data/orthanc-storage \
    --orthanc-user USER \
    --orthanc-password PASS
```
 
- orthanc_storage_dir and the staging directory (data/sorted) must be on the same filesystem (same PVC) for hardlinks to work.


I have tested with dummy DICOM data and test eDICOM data, sort and upload worked just as before. Perhaps a benchmark comparing this approach to the previous might be useful in the future.


Review:
- Code check

