### PR TITLE
Development of AIS deidentification methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "pydicom >=2.3.1",
     "tqdm >=4.64.1",
     "boto3",
+    "cryptography",
     "natsort",
     "paramiko",
     "xnat",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "cryptography",
     "natsort",
     "paramiko",
-    "xnat",
+    "xnat==0.7.2",
     "frametree",
     "frametree-xnat",
 ]

--- a/xnat_ingest/api/__init__.py
+++ b/xnat_ingest/api/__init__.py
@@ -1,8 +1,8 @@
 from .associate_ import associate
 from .check_upload_ import check_upload
-from .deidentify_ import deidentify
 from .sort_ import sort, list_session_dirs, BUILD_NAME_DEFAULT, INVALID_NAME_DEFAULT
 from .upload_ import upload
+from .deidentify_ import deidentify
 
 __all__ = [
     "upload",

--- a/xnat_ingest/api/deidentify_.py
+++ b/xnat_ingest/api/deidentify_.py
@@ -11,7 +11,6 @@ from fileformats.medimage.base import MedicalImagingData
 from fileformats.medimage.dicom import DicomImage
 from fileformats.core import FileSet
 from tqdm import tqdm
-import yaml
 
 from xnat_ingest.helpers.remotes import LocalSessionListing
 
@@ -56,8 +55,8 @@ def deidentify(
                 require_manifest=require_manifest,
                 check_checksums=False,
             )
-            with open(spec_dir / f"{session.project_id}.yaml") as f:
-                project_spec_mime = yaml.load(f)
+            with open(spec_dir / f"{session.project_id}.json") as f:
+                project_spec_mime = json.load(f)
                 # Convert the project spec keys from mime-like strings to FileSet types
                 try:
                     project_spec = {
@@ -66,7 +65,7 @@ def deidentify(
                 except FormatRecognitionError as e:
                     raise ValueError(
                         f"Error parsing project specification for project {session.project_id} from "
-                        f"{spec_dir / f'{session.project_id}.yaml'}, unrecognised fileformat: {str(e)}"
+                        f"{spec_dir / f'{session.project_id}.json'}, unrecognised fileformat: {str(e)}"
                     ) from e
 
             deidentified_session, reid_mdata = session.deidentify(

--- a/xnat_ingest/api/deidentify_.py
+++ b/xnat_ingest/api/deidentify_.py
@@ -1,6 +1,14 @@
+import os
+import json
 import traceback
 from pathlib import Path
+import typing as ty
 
+from cryptography.fernet import Fernet
+from fileformats.core import extra_implementation, from_mime
+from fileformats.core.exceptions import FormatRecognitionError
+from fileformats.medimage.base import MedicalImagingData
+from fileformats.medimage.dicom import DicomImage
 from fileformats.core import FileSet
 from tqdm import tqdm
 
@@ -13,11 +21,14 @@ from ..model.session import ImagingSession
 def deidentify(
     input_dir: Path,
     output_dir: Path,
+    spec_dir: Path,
+    reid_dir: Path,
     avoid_clashes: bool = False,
     raise_errors: bool = False,
     copy_mode: FileSet.CopyMode = FileSet.CopyMode.copy,
     require_manifest: bool = True,
     delete: bool = False,
+    reid_encrypt_key: bytes | None = None,
 ) -> list[str]:
 
     sessions: list[LocalSessionListing] = [
@@ -44,20 +55,57 @@ def deidentify(
                 require_manifest=require_manifest,
                 check_checksums=False,
             )
-            deidentified_session = session.deidentify(
+            with open(spec_dir / f"{session.project_id}.json") as f:
+                project_spec_mime = json.load(f)
+                # Convert the project spec keys from mime-like strings to FileSet types
+                try:
+                    project_spec = {
+                        from_mime(k): v for k, v in project_spec_mime.items()
+                    }
+                except FormatRecognitionError as e:
+                    raise ValueError(
+                        f"Error parsing project specification for project {session.project_id} from "
+                        f"{spec_dir / f'{session.project_id}.json'}, unrecognised fileformat: {str(e)}"
+                    ) from e
+
+            deidentified_session, reid_mdata = session.deidentify(
                 output_dir,
                 copy_mode=copy_mode,
                 avoid_clashes=avoid_clashes,
+                project_spec=project_spec,
+                reid_dir=reid_dir,
             )
             deidentified_session.save(output_dir / session_listing.name)
+            reid_mdata_json = json.dumps(reid_mdata, indent=2).encode()
+            if reid_encrypt_key is not None:
+                reid_fspath = reid_dir / f"{session_listing.name}.json.enc"
+                reid_fspath.write_bytes(
+                    Fernet(reid_encrypt_key).encrypt(reid_mdata_json)
+                )
+            else:
+                reid_fspath = reid_dir / f"{session_listing.name}.json"
+                reid_fspath.write_bytes(reid_mdata_json)
         except Exception as e:
             if raise_errors:
                 raise
             logger.error(
                 "Error deidentifying session '%s': %s",
-                session_listing.session_dir,
+                session_listing.session_id,
                 str(e),
             )
             logger.debug(traceback.format_exc())
             errors.append(str(e))
+        else:
+            if delete:
+                # remove the original session directory after successful deidentification
+                session_listing.session_dir.rmdir()
     return errors
+
+
+@extra_implementation(MedicalImagingData.deidentify)
+def dicom_deidentify(
+    dicom: DicomImage,
+    spec: ty.Any = None,
+    out_dir: os.PathLike[str] | None = None,
+) -> tuple[DicomImage, ty.Mapping[str, ty.Any]]:
+    raise NotImplementedError

--- a/xnat_ingest/api/deidentify_.py
+++ b/xnat_ingest/api/deidentify_.py
@@ -11,6 +11,7 @@ from fileformats.medimage.base import MedicalImagingData
 from fileformats.medimage.dicom import DicomImage
 from fileformats.core import FileSet
 from tqdm import tqdm
+import yaml
 
 from xnat_ingest.helpers.remotes import LocalSessionListing
 
@@ -55,8 +56,8 @@ def deidentify(
                 require_manifest=require_manifest,
                 check_checksums=False,
             )
-            with open(spec_dir / f"{session.project_id}.json") as f:
-                project_spec_mime = json.load(f)
+            with open(spec_dir / f"{session.project_id}.yaml") as f:
+                project_spec_mime = yaml.load(f)
                 # Convert the project spec keys from mime-like strings to FileSet types
                 try:
                     project_spec = {
@@ -65,7 +66,7 @@ def deidentify(
                 except FormatRecognitionError as e:
                     raise ValueError(
                         f"Error parsing project specification for project {session.project_id} from "
-                        f"{spec_dir / f'{session.project_id}.json'}, unrecognised fileformat: {str(e)}"
+                        f"{spec_dir / f'{session.project_id}.yaml'}, unrecognised fileformat: {str(e)}"
                     ) from e
 
             deidentified_session, reid_mdata = session.deidentify(

--- a/xnat_ingest/api/deidentify_.py
+++ b/xnat_ingest/api/deidentify_.py
@@ -6,7 +6,6 @@ import typing as ty
 
 from cryptography.fernet import Fernet
 from fileformats.core import extra_implementation, from_mime
-from fileformats.core.exceptions import FormatRecognitionError
 from fileformats.medimage.base import MedicalImagingData
 from fileformats.medimage.dicom import DicomImage
 from fileformats.core import FileSet
@@ -16,6 +15,7 @@ from xnat_ingest.helpers.remotes import LocalSessionListing
 
 from ..helpers.logging import logger
 from ..model.session import ImagingSession
+from . import list_session_dirs
 
 
 def deidentify(
@@ -32,7 +32,7 @@ def deidentify(
 ) -> list[str]:
 
     sessions: list[LocalSessionListing] = [
-        LocalSessionListing(p) for p in Path(input_dir).iterdir()
+        LocalSessionListing(d) for d in list_session_dirs(input_dir)
     ]
     num_sessions = len(sessions)
     logger.info(
@@ -40,6 +40,10 @@ def deidentify(
         num_sessions,
         input_dir,
     )
+
+    # Ensure the output and reid directories exist
+    output_dir.mkdir(parents=True, exist_ok=True)
+    reid_dir.mkdir(parents=True, exist_ok=True)
 
     errors: list[str] = []
 
@@ -55,25 +59,20 @@ def deidentify(
                 require_manifest=require_manifest,
                 check_checksums=False,
             )
-            with open(spec_dir / f"{session.project_id}.json") as f:
-                project_spec_mime = json.load(f)
-                # Convert the project spec keys from mime-like strings to FileSet types
-                try:
-                    project_spec = {
-                        from_mime(k): v for k, v in project_spec_mime.items()
-                    }
-                except FormatRecognitionError as e:
-                    raise ValueError(
-                        f"Error parsing project specification for project {session.project_id} from "
-                        f"{spec_dir / f'{session.project_id}.json'}, unrecognised fileformat: {str(e)}"
-                    ) from e
+            # Get the project-specific deidentification specs for this session
+            # for each file type
+            project_spec_dir = spec_dir / session.project_id
+            project_spec = {
+                from_mime(p.name.replace("@", "/")): p
+                for p in project_spec_dir.iterdir()
+                if "@" in p.name
+            }
 
             deidentified_session, reid_mdata = session.deidentify(
                 output_dir,
                 copy_mode=copy_mode,
                 avoid_clashes=avoid_clashes,
                 project_spec=project_spec,
-                reid_dir=reid_dir,
             )
             deidentified_session.save(output_dir / session_listing.name)
             reid_mdata_json = json.dumps(reid_mdata, indent=2).encode()

--- a/xnat_ingest/api/tests/test_deidentify.py
+++ b/xnat_ingest/api/tests/test_deidentify.py
@@ -17,7 +17,7 @@ REID_MDATA = {"PatientName": "John Doe", "DOB": "19800101", "PatientID": "PID001
 
 
 @pytest.fixture
-def dirs(tmp_path: Path):
+def dirs(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
     input_dir = tmp_path / "input"
     output_dir = tmp_path / "output"
     spec_dir = tmp_path / "spec"
@@ -29,11 +29,11 @@ def dirs(tmp_path: Path):
     return input_dir, output_dir, spec_dir, reid_dir
 
 
-def _mock_deidentify(self, dest_dir, **kwargs):
+def _mock_deidentify(self, dest_dir, **kwargs) -> tuple[ImagingSession, dict]:
     return self.new_empty(), dict(REID_MDATA)
 
 
-def test_deidentify_plain_json(dirs):
+def test_deidentify_plain_json(dirs: tuple[Path, Path, Path, Path]):
     input_dir, output_dir, spec_dir, reid_dir = dirs
 
     with patch.object(ImagingSession, "deidentify", _mock_deidentify):
@@ -50,7 +50,7 @@ def test_deidentify_plain_json(dirs):
     assert json.loads(reid_file.read_bytes()) == REID_MDATA
 
 
-def test_deidentify_encrypted(dirs):
+def test_deidentify_encrypted(dirs: tuple[Path, Path, Path, Path]) -> None:
     input_dir, output_dir, spec_dir, reid_dir = dirs
     key = Fernet.generate_key()
 
@@ -71,7 +71,7 @@ def test_deidentify_encrypted(dirs):
     assert decrypted == REID_MDATA
 
 
-def test_deidentify_wrong_key_fails(dirs):
+def test_deidentify_wrong_key_fails(dirs: tuple[Path, Path, Path, Path]):
     input_dir, output_dir, spec_dir, reid_dir = dirs
     encrypt_key = Fernet.generate_key()
     wrong_key = Fernet.generate_key()
@@ -90,7 +90,7 @@ def test_deidentify_wrong_key_fails(dirs):
         Fernet(wrong_key).decrypt(enc_file.read_bytes())
 
 
-def test_deidentify_error_collected(dirs):
+def test_deidentify_error_collected(dirs: tuple[Path, Path, Path, Path]):
     input_dir, output_dir, spec_dir, reid_dir = dirs
 
     def failing_deidentify(self, dest_dir, **kwargs):
@@ -109,7 +109,7 @@ def test_deidentify_error_collected(dirs):
     assert not list(reid_dir.iterdir())
 
 
-def test_deidentify_raise_errors(dirs):
+def test_deidentify_raise_errors(dirs: tuple[Path, Path, Path, Path]):
     input_dir, output_dir, spec_dir, reid_dir = dirs
 
     def failing_deidentify(self, dest_dir, **kwargs):

--- a/xnat_ingest/api/tests/test_deidentify.py
+++ b/xnat_ingest/api/tests/test_deidentify.py
@@ -23,9 +23,9 @@ def dirs(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
     spec_dir = tmp_path / "spec"
     reid_dir = tmp_path / "reid"
     for d in [input_dir, output_dir, spec_dir, reid_dir]:
-        d.mkdir()
+        d.mkdir(parents=True)
     (input_dir / SESSION_NAME).mkdir()
-    (spec_dir / f"{PROJECT_ID}.json").write_text("{}")
+    (spec_dir / PROJECT_ID).mkdir()
     return input_dir, output_dir, spec_dir, reid_dir
 
 
@@ -137,7 +137,7 @@ def test_deidentify_multiple_sessions(tmp_path: Path):
     session_names = [f"PROJ.SUBJ{i}.SESS{i}" for i in range(3)]
     for name in session_names:
         (input_dir / name).mkdir()
-    (spec_dir / "PROJ.json").write_text("{}")
+    (spec_dir / "PROJ").mkdir()
 
     with patch.object(ImagingSession, "deidentify", _mock_deidentify):
         errors = deidentify(
@@ -154,7 +154,7 @@ def test_deidentify_multiple_sessions(tmp_path: Path):
 
 def test_deidentify_missing_spec_collected(dirs):
     input_dir, output_dir, spec_dir, reid_dir = dirs
-    (spec_dir / f"{PROJECT_ID}.json").unlink()
+    (spec_dir / PROJECT_ID).rmdir()
 
     with patch.object(ImagingSession, "deidentify", _mock_deidentify):
         errors = deidentify(

--- a/xnat_ingest/api/tests/test_deidentify.py
+++ b/xnat_ingest/api/tests/test_deidentify.py
@@ -1,0 +1,167 @@
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from cryptography.fernet import Fernet
+
+from xnat_ingest.api.deidentify_ import deidentify
+from xnat_ingest.model.session import ImagingSession
+
+PROJECT_ID = "PROJ"
+SUBJECT_ID = "SUBJ"
+VISIT_ID = "SESS"
+SESSION_NAME = f"{PROJECT_ID}.{SUBJECT_ID}.{VISIT_ID}"
+
+REID_MDATA = {"PatientName": "John Doe", "DOB": "19800101", "PatientID": "PID001"}
+
+
+@pytest.fixture
+def dirs(tmp_path: Path):
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    spec_dir = tmp_path / "spec"
+    reid_dir = tmp_path / "reid"
+    for d in [input_dir, output_dir, spec_dir, reid_dir]:
+        d.mkdir()
+    (input_dir / SESSION_NAME).mkdir()
+    (spec_dir / f"{PROJECT_ID}.json").write_text("{}")
+    return input_dir, output_dir, spec_dir, reid_dir
+
+
+def _mock_deidentify(self, dest_dir, **kwargs):
+    return self.new_empty(), dict(REID_MDATA)
+
+
+def test_deidentify_plain_json(dirs):
+    input_dir, output_dir, spec_dir, reid_dir = dirs
+
+    with patch.object(ImagingSession, "deidentify", _mock_deidentify):
+        errors = deidentify(
+            input_dir=input_dir,
+            output_dir=output_dir,
+            spec_dir=spec_dir,
+            reid_dir=reid_dir,
+        )
+
+    assert errors == []
+    reid_file = reid_dir / f"{SESSION_NAME}.json"
+    assert reid_file.exists()
+    assert json.loads(reid_file.read_bytes()) == REID_MDATA
+
+
+def test_deidentify_encrypted(dirs):
+    input_dir, output_dir, spec_dir, reid_dir = dirs
+    key = Fernet.generate_key()
+
+    with patch.object(ImagingSession, "deidentify", _mock_deidentify):
+        errors = deidentify(
+            input_dir=input_dir,
+            output_dir=output_dir,
+            spec_dir=spec_dir,
+            reid_dir=reid_dir,
+            reid_encrypt_key=key,
+        )
+
+    assert errors == []
+    enc_file = reid_dir / f"{SESSION_NAME}.json.enc"
+    assert enc_file.exists()
+    assert not (reid_dir / f"{SESSION_NAME}.json").exists()
+    decrypted = json.loads(Fernet(key).decrypt(enc_file.read_bytes()))
+    assert decrypted == REID_MDATA
+
+
+def test_deidentify_wrong_key_fails(dirs):
+    input_dir, output_dir, spec_dir, reid_dir = dirs
+    encrypt_key = Fernet.generate_key()
+    wrong_key = Fernet.generate_key()
+
+    with patch.object(ImagingSession, "deidentify", _mock_deidentify):
+        deidentify(
+            input_dir=input_dir,
+            output_dir=output_dir,
+            spec_dir=spec_dir,
+            reid_dir=reid_dir,
+            reid_encrypt_key=encrypt_key,
+        )
+
+    enc_file = reid_dir / f"{SESSION_NAME}.json.enc"
+    with pytest.raises(Exception):
+        Fernet(wrong_key).decrypt(enc_file.read_bytes())
+
+
+def test_deidentify_error_collected(dirs):
+    input_dir, output_dir, spec_dir, reid_dir = dirs
+
+    def failing_deidentify(self, dest_dir, **kwargs):
+        raise RuntimeError("simulated deidentification failure")
+
+    with patch.object(ImagingSession, "deidentify", failing_deidentify):
+        errors = deidentify(
+            input_dir=input_dir,
+            output_dir=output_dir,
+            spec_dir=spec_dir,
+            reid_dir=reid_dir,
+        )
+
+    assert len(errors) == 1
+    assert "simulated deidentification failure" in errors[0]
+    assert not list(reid_dir.iterdir())
+
+
+def test_deidentify_raise_errors(dirs):
+    input_dir, output_dir, spec_dir, reid_dir = dirs
+
+    def failing_deidentify(self, dest_dir, **kwargs):
+        raise RuntimeError("simulated deidentification failure")
+
+    with patch.object(ImagingSession, "deidentify", failing_deidentify):
+        with pytest.raises(RuntimeError, match="simulated deidentification failure"):
+            deidentify(
+                input_dir=input_dir,
+                output_dir=output_dir,
+                spec_dir=spec_dir,
+                reid_dir=reid_dir,
+                raise_errors=True,
+            )
+
+
+def test_deidentify_multiple_sessions(tmp_path: Path):
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    spec_dir = tmp_path / "spec"
+    reid_dir = tmp_path / "reid"
+    for d in [input_dir, output_dir, spec_dir, reid_dir]:
+        d.mkdir()
+
+    session_names = [f"PROJ.SUBJ{i}.SESS{i}" for i in range(3)]
+    for name in session_names:
+        (input_dir / name).mkdir()
+    (spec_dir / "PROJ.json").write_text("{}")
+
+    with patch.object(ImagingSession, "deidentify", _mock_deidentify):
+        errors = deidentify(
+            input_dir=input_dir,
+            output_dir=output_dir,
+            spec_dir=spec_dir,
+            reid_dir=reid_dir,
+        )
+
+    assert errors == []
+    for name in session_names:
+        assert (reid_dir / f"{name}.json").exists()
+
+
+def test_deidentify_missing_spec_collected(dirs):
+    input_dir, output_dir, spec_dir, reid_dir = dirs
+    (spec_dir / f"{PROJECT_ID}.json").unlink()
+
+    with patch.object(ImagingSession, "deidentify", _mock_deidentify):
+        errors = deidentify(
+            input_dir=input_dir,
+            output_dir=output_dir,
+            spec_dir=spec_dir,
+            reid_dir=reid_dir,
+        )
+
+    assert len(errors) == 1

--- a/xnat_ingest/cli/deidentify.py
+++ b/xnat_ingest/cli/deidentify.py
@@ -8,6 +8,7 @@ from fileformats.core import FileSet
 
 from xnat_ingest.cli.base import base_cli
 
+from ..api.deidentify_ import deidentify as deidentify_sessions
 from ..helpers.arg_types import CopyModeParamType, LoggerConfig
 from ..helpers.logging import logger, set_logger_handling
 
@@ -97,17 +98,16 @@ by --reid-encrypt-key option) and saved in the REID_DIR.
 @click.option(
     "--raise-errors/--dont-raise-errors",
     default=False,
-    type=bool,
     help="Whether to raise errors instead of logging them (typically for debugging)",
 )
 @click.option(
-    "--deidentify/--dont-deidentify",
-    default=False,
-    type=bool,
-    envvar="XINGEST_DEIDENTIFY",
+    "--require-manifest/--no-require-manifest",
+    default=True,
+    envvar="XINGEST_REQUIRE_MANIFEST",
     help=(
-        "whether to deidentify the file names and DICOM metadata before staging "
-        "(XINGEST_DEIDENTIFY env. var)"
+        "Whether to require a MANIFEST.json file in each resource directory. "
+        "If False, resources are loaded as generic FileSets without checksum validation "
+        "(XINGEST_REQUIRE_MANIFEST env. var)"
     ),
 )
 @click.option(
@@ -135,14 +135,8 @@ by --reid-encrypt-key option) and saved in the REID_DIR.
     ),
 )
 @click.option(
-    "--recursive/--not-recursive",
-    type=bool,
-    default=False,
-    help=("Whether to recursively search input directories for input files"),
-)
-@click.option(
     "--reid-encrypt-key",
-    type=bytes,
+    type=str,
     default=None,
     envvar="XINGEST_REID_ENCRYPT_KEY",
     help=(
@@ -152,7 +146,7 @@ by --reid-encrypt-key option) and saved in the REID_DIR.
     ),
 )
 def deidentify_cli(
-    input_dir: Path,
+    input_dir: ty.Tuple[Path, ...],
     output_dir: Path,
     spec_dir: Path,
     reid_dir: Path,
@@ -160,12 +154,11 @@ def deidentify_cli(
     additional_loggers: ty.List[str],
     require_manifest: bool,
     raise_errors: bool,
-    deidentify: bool,
     copy_mode: FileSet.CopyMode,
     loop: int,
     avoid_clashes: bool,
     delete: bool,
-    reid_encrypt_key: bytes | None = None,
+    reid_encrypt_key: str | None = None,
 ) -> None:
 
     if raise_errors and loop >= 0:
@@ -179,35 +172,40 @@ def deidentify_cli(
         additional_loggers=additional_loggers,
     )
 
+    encrypt_key_bytes: bytes | None = (
+        reid_encrypt_key.encode() if reid_encrypt_key is not None else None
+    )
+
     # Run the staging process in a loop if loop is set to a positive value, otherwise
     # just run it once
     while True:
         start_time = datetime.datetime.now()
-        errors = deidentify(
-            input_dir=input_dir,
-            output_dir=output_dir,
-            spec_dir=spec_dir,
-            reid_dir=reid_dir,
-            avoid_clashes=avoid_clashes,
-            raise_errors=raise_errors,
-            copy_mode=copy_mode,
-            require_manifest=require_manifest,
-            delete=delete,
-            reid_encrypt_key=reid_encrypt_key,
-        )
-        if errors:
-            logger.error(
-                f"Staging completed with {len(errors)} errors:\n\n{''.join(errors)}"
+        for in_dir in input_dir:
+            errors = deidentify_sessions(
+                input_dir=in_dir,
+                output_dir=output_dir,
+                spec_dir=spec_dir,
+                reid_dir=reid_dir,
+                avoid_clashes=avoid_clashes,
+                raise_errors=raise_errors,
+                copy_mode=copy_mode,
+                require_manifest=require_manifest,
+                delete=delete,
+                reid_encrypt_key=encrypt_key_bytes,
             )
-        else:
-            logger.info("Staging completed successfully")
+            if errors:
+                logger.error(
+                    f"Deidentification completed with {len(errors)} errors:\n\n{''.join(errors)}"
+                )
+            else:
+                logger.info("Deidentification completed successfully")
         if loop < 0:
             break
         end_time = datetime.datetime.now()
         elapsed_seconds = (end_time - start_time).total_seconds()
         sleep_time = loop - elapsed_seconds
         logger.info(
-            "Stage took %s seconds, waiting another %s seconds before running "
+            "Deidentify took %s seconds, waiting another %s seconds before running "
             "again (loop every %s seconds)",
             elapsed_seconds,
             sleep_time,

--- a/xnat_ingest/cli/deidentify.py
+++ b/xnat_ingest/cli/deidentify.py
@@ -23,6 +23,21 @@ INPUT_DIR is either the path to a directory containing the files to deidentify
 
 OUTPUT_DIR is the directory that the files for each session are collated to before they
 are uploaded to XNAT
+
+SPEC_DIR is the directory containing the project-specific deidentification specifications.
+Each project specification should be a JSON file named <project_id>.json that contains a mapping
+from file format identifiers (e.g. DICOM, NIfTI, etc.) to the deidentification specification to use for
+files of that format in that project. The file format identifiers should be in the form of
+MIME types (e.g. 'application/dicom') or more specific file format identifiers recognized by the
+fileformats package (e.g. 'application/dicom; transfer-syntax=1.2.840.10008.1.2.1').
+
+REID_DIR is the directory to save the re-identification metadata to, which can be used to
+re-identify the de-identified data if needed. The re-identification metadata is saved in
+JSON format, with one JSON file per session, containing a list of mappings from original
+to de-identified identifiers for each resource in the session, as well as any additional
+metadata needed for re-identification (e.g. DICOM tags that were modified during de-identification).
+The re-identification metadata files are named <session_id>.json (or <session_id>.json.enc if encrypted
+by --reid-encrypt-key option) and saved in the REID_DIR.
 """,
 )
 @click.argument(
@@ -33,6 +48,16 @@ are uploaded to XNAT
 )
 @click.argument(
     "output_dir", type=click.Path(path_type=Path), envvar="XINGEST_OUTPUT_DIR"
+)
+@click.argument(
+    "spec_dir",
+    type=click.Path(path_type=Path, exists=True),
+    envvar="XINGEST_SPEC_DIR",
+)
+@click.argument(
+    "reid_dir",
+    type=click.Path(path_type=Path),
+    envvar="XINGEST_REID_DIR",
 )
 @click.option(
     "--delete/--dont-delete",
@@ -115,9 +140,22 @@ are uploaded to XNAT
     default=False,
     help=("Whether to recursively search input directories for input files"),
 )
+@click.option(
+    "--reid-encrypt-key",
+    type=bytes,
+    default=None,
+    envvar="XINGEST_REID_ENCRYPT_KEY",
+    help=(
+        "An optional encryption key to use for encrypting the re-identification metadata "
+        "(XINGEST_REID_ENCRYPT_KEY env. var). This should be a URL-safe base64-encoded 32-byte key, "
+        "e.g. generated using `Fernet.generate_key()` from the cryptography package"
+    ),
+)
 def deidentify_cli(
     input_dir: Path,
     output_dir: Path,
+    spec_dir: Path,
+    reid_dir: Path,
     loggers: ty.List[LoggerConfig],
     additional_loggers: ty.List[str],
     require_manifest: bool,
@@ -127,6 +165,7 @@ def deidentify_cli(
     loop: int,
     avoid_clashes: bool,
     delete: bool,
+    reid_encrypt_key: bytes | None = None,
 ) -> None:
 
     if raise_errors and loop >= 0:
@@ -147,11 +186,14 @@ def deidentify_cli(
         errors = deidentify(
             input_dir=input_dir,
             output_dir=output_dir,
+            spec_dir=spec_dir,
+            reid_dir=reid_dir,
             avoid_clashes=avoid_clashes,
             raise_errors=raise_errors,
             copy_mode=copy_mode,
             require_manifest=require_manifest,
             delete=delete,
+            reid_encrypt_key=reid_encrypt_key,
         )
         if errors:
             logger.error(

--- a/xnat_ingest/cli/deidentify.py
+++ b/xnat_ingest/cli/deidentify.py
@@ -8,7 +8,7 @@ from fileformats.core import FileSet
 
 from xnat_ingest.cli.base import base_cli
 
-from ..api.deidentify_ import deidentify as deidentify_sessions
+from ..api.deidentify_ import deidentify
 from ..helpers.arg_types import CopyModeParamType, LoggerConfig
 from ..helpers.logging import logger, set_logger_handling
 
@@ -20,7 +20,10 @@ DEIDENTIFIED_NAME_DEFAULT = "DEIDENTIFIED"
     help="""Stages images found in the input directories into separate directories for each
 imaging acquisition session
 
-INPUT_DIR is either the path to a directory containing the files to deidentify
+INPUT_DIR is the path to the directory containing the session directories to de-identify.
+Each session directory should be named in the format <project_id>.<subject_id>.<visit_id>
+and contain subdirectories for each scan, which in turn contain the resource files for
+each scan.
 
 OUTPUT_DIR is the directory that the files for each session are collated to before they
 are uploaded to XNAT
@@ -44,7 +47,6 @@ by --reid-encrypt-key option) and saved in the REID_DIR.
 @click.argument(
     "input_dir",
     type=click.Path(path_type=Path, exists=True),
-    nargs=-1,
     envvar="XINGEST_INPUT_DIR",
 )
 @click.argument(
@@ -146,7 +148,7 @@ by --reid-encrypt-key option) and saved in the REID_DIR.
     ),
 )
 def deidentify_cli(
-    input_dir: ty.Tuple[Path, ...],
+    input_dir: Path,
     output_dir: Path,
     spec_dir: Path,
     reid_dir: Path,
@@ -180,25 +182,24 @@ def deidentify_cli(
     # just run it once
     while True:
         start_time = datetime.datetime.now()
-        for in_dir in input_dir:
-            errors = deidentify_sessions(
-                input_dir=in_dir,
-                output_dir=output_dir,
-                spec_dir=spec_dir,
-                reid_dir=reid_dir,
-                avoid_clashes=avoid_clashes,
-                raise_errors=raise_errors,
-                copy_mode=copy_mode,
-                require_manifest=require_manifest,
-                delete=delete,
-                reid_encrypt_key=encrypt_key_bytes,
+        errors = deidentify(
+            input_dir=input_dir,
+            output_dir=output_dir,
+            spec_dir=spec_dir,
+            reid_dir=reid_dir,
+            avoid_clashes=avoid_clashes,
+            raise_errors=raise_errors,
+            copy_mode=copy_mode,
+            require_manifest=require_manifest,
+            delete=delete,
+            reid_encrypt_key=encrypt_key_bytes,
+        )
+        if errors:
+            logger.error(
+                f"Deidentification completed with {len(errors)} errors:\n\n{''.join(errors)}"
             )
-            if errors:
-                logger.error(
-                    f"Deidentification completed with {len(errors)} errors:\n\n{''.join(errors)}"
-                )
-            else:
-                logger.info("Deidentification completed successfully")
+        else:
+            logger.info("Deidentification completed successfully")
         if loop < 0:
             break
         end_time = datetime.datetime.now()

--- a/xnat_ingest/cli/tests/test_cli.py
+++ b/xnat_ingest/cli/tests/test_cli.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 import time
@@ -10,6 +11,7 @@ import click
 import xnat4tests  # type: ignore[import-untyped]
 from fileformats.application import Json, Yaml
 from fileformats.medimage import DicomSeries
+from fileformats.medimage.base import MedicalImagingData
 from fileformats.testing import MyFormat, MyFormatGz
 from frametree.core.cli import add_source as dataset_add_source
 from frametree.core.cli import define as dataset_define  # type: ignore[import-untyped]
@@ -29,7 +31,13 @@ from medimages4tests.dummy.dicom.pet.wholebody.siemens.biograph_vision.vr20b imp
 from moto import mock_aws
 
 from conftest import get_raw_data_files, show_cli_trace
-from xnat_ingest.cli import associate_cli, check_upload_cli, sort_cli, upload_cli
+from xnat_ingest.cli import (
+    associate_cli,
+    check_upload_cli,
+    deidentify_cli,
+    sort_cli,
+    upload_cli,
+)
 from xnat_ingest.api import INVALID_NAME_DEFAULT, list_session_dirs
 from xnat_ingest.helpers.arg_types import MimeType  # type: ignore[import-untyped]
 from xnat_ingest.helpers.arg_types import FieldSpec, XnatLogin
@@ -37,6 +45,11 @@ from xnat_ingest.helpers.remotes import upload_file_to_s3
 from xnat_ingest.model.session import ImagingSession
 
 PATTERN = "{PatientName.family_name}_{PatientName.given_name}_{SeriesDate}.*"
+
+
+DICOM_DEID_SPEC = """
+# Specification for de-identifying DICOM files for project PROJ goes here
+"""
 
 
 @click.command(
@@ -1180,6 +1193,188 @@ def test_check_upload_checksum_fail(
     assert "MISSING RESOURCE" not in logs
     assert "EMPTY SCAN" not in logs
     assert "CHECKSUM FAIL" in logs
+
+
+def _mock_dicom_deidentify(
+    self: MedicalImagingData,
+    spec: ty.Any = None,
+    out_dir: ty.Optional[Path] = None,
+) -> tuple:
+    """Stand-in for dicom_deidentify (not yet implemented by the colleague).
+
+    Copies the fileset to out_dir and returns a minimal reid metadata dict
+    containing the original PatientName and PatientID so the tests can assert
+    that PHI values are captured and persisted.
+    """
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    copied = self.copy(out_dir)
+    reid = {
+        "PatientName": str(self.metadata.get("PatientName", "")),
+        "PatientID": str(self.metadata.get("PatientID", "")),
+    }
+    return copied, reid
+
+
+def test_deidentify_cli_dicom(
+    cli_runner: ty.Any,
+    tmp_path: Path,
+) -> None:
+    """Sort DICOM sessions then run deidentify_cli end-to-end.
+
+    MedicalImagingData.deidentify is mocked (the real implementation will be
+    provided by a colleague).  The test verifies the full pipeline: staging →
+    session loading → spec parsing → deidentification → reid persistence.
+    """
+    PROJECT_ID = "TESTDEIDPROJECT"
+    PATIENT_ID = "subject1"
+    ACCESSION = "ACC001"
+    STUDY_UID = "1.2.3.4.5.6.7.8.9.0"
+
+    # 1. Generate DICOM test data for multiple scan types in subdirectories
+    dicoms_dir = tmp_path / "dicoms"
+    dicoms_dir.mkdir()
+    for get_image, subdir in [
+        (get_pet_image, "pet"),
+        (get_ac_image, "ac"),
+        (get_topogram_image, "topogram"),
+    ]:
+        get_image(
+            dicoms_dir / subdir,
+            StudyID=PROJECT_ID,
+            PatientID=PATIENT_ID,
+            AccessionNumber=ACCESSION,
+            StudyInstanceUID=STUDY_UID,
+        )
+
+    # 2. Stage with sort_cli
+    staged_dir = tmp_path / "staged"
+    staged_dir.mkdir()
+    sort_log = tmp_path / "sort.log"
+    result = cli_runner(
+        sort_cli,
+        [
+            str(dicoms_dir),
+            str(staged_dir),
+            "--raise-errors",
+            "--wait-period",
+            "0",
+            "--recursive",
+        ],
+        env={"XINGEST_LOGGERS": f"file debug {sort_log};stream info stdout"},
+    )
+    assert result.exit_code == 0, show_cli_trace(result)
+
+    session_name = f"{PROJECT_ID}.{PATIENT_ID}.{ACCESSION}"
+    assert (staged_dir / session_name).exists(), "Session not staged"
+
+    # 3. Project spec mapping DicomSeries to an empty spec dict
+    spec_dir = tmp_path / "spec"
+    spec_dir.mkdir()
+    (spec_dir / f"{PROJECT_ID}.json").write_text(
+        '{"medimage/dicom-series": DICOM_DEID_SPEC}'
+    )
+
+    # 4. Run deidentify_cli with the mock deidentify implementation
+    output_dir = tmp_path / "deidentified"
+    reid_dir = tmp_path / "reid"
+    deid_log = tmp_path / "deid.log"
+
+    with patch.object(MedicalImagingData, "deidentify", _mock_dicom_deidentify):
+        result = cli_runner(
+            deidentify_cli,
+            [
+                str(staged_dir),
+                str(output_dir),
+                str(spec_dir),
+                str(reid_dir),
+                "--raise-errors",
+            ],
+            env={"XINGEST_LOGGERS": f"file info {deid_log};stream info stdout"},
+        )
+    assert result.exit_code == 0, show_cli_trace(result)
+
+    # 5. Log reports success
+    logs = deid_log.read_text()
+    assert "Deidentification completed successfully" in logs, show_cli_trace(result)
+
+    # 6. Reid metadata captures original PHI values
+    reid_file = reid_dir / f"{session_name}.json"
+    assert reid_file.exists(), f"Reid file missing: {reid_file}"
+    reid = json.loads(reid_file.read_bytes())
+    assert reid.get("PatientID") == PATIENT_ID
+    assert reid.get("PatientName") != ""
+
+    # 7. Deidentified session directory contains files
+    deid_session_root = output_dir / session_name
+    assert deid_session_root.exists()
+    assert any(
+        p.is_file() for p in deid_session_root.rglob("*")
+    ), f"No files found under {deid_session_root}"
+
+
+def test_deidentify_cli_dicom_encrypted_reid(
+    cli_runner: ty.Any,
+    tmp_path: Path,
+) -> None:
+    """Deidentify with --reid-encrypt-key produces a decryptable .json.enc file."""
+    from cryptography.fernet import Fernet
+
+    PROJECT_ID = "TESTDEIDENCPROJECT"
+    PATIENT_ID = "subject1"
+    ACCESSION = "ACC001"
+    STUDY_UID = "1.2.3.4.5.6.7.8.9.1"
+
+    dicoms_dir = tmp_path / "dicoms"
+    dicoms_dir.mkdir()
+    get_pet_image(
+        dicoms_dir,
+        StudyID=PROJECT_ID,
+        PatientID=PATIENT_ID,
+        AccessionNumber=ACCESSION,
+        StudyInstanceUID=STUDY_UID,
+    )
+
+    staged_dir = tmp_path / "staged"
+    staged_dir.mkdir()
+    result = cli_runner(
+        sort_cli,
+        [str(dicoms_dir), str(staged_dir), "--raise-errors", "--wait-period", "0"],
+    )
+    assert result.exit_code == 0, show_cli_trace(result)
+
+    spec_dir = tmp_path / "spec"
+    spec_dir.mkdir()
+    (spec_dir / f"{PROJECT_ID}.json").write_text(
+        '{"medimage/dicom-series": DICOM_DEID_SPEC}'
+    )
+
+    output_dir = tmp_path / "deidentified"
+    reid_dir = tmp_path / "reid"
+    key = Fernet.generate_key()
+
+    with patch.object(MedicalImagingData, "deidentify", _mock_dicom_deidentify):
+        result = cli_runner(
+            deidentify_cli,
+            [
+                str(staged_dir),
+                str(output_dir),
+                str(spec_dir),
+                str(reid_dir),
+                "--raise-errors",
+                "--reid-encrypt-key",
+                key.decode(),
+            ],
+        )
+    assert result.exit_code == 0, show_cli_trace(result)
+
+    session_name = f"{PROJECT_ID}.{PATIENT_ID}.{ACCESSION}"
+    enc_file = reid_dir / f"{session_name}.json.enc"
+    assert enc_file.exists(), f"Encrypted reid file missing: {enc_file}"
+    assert not (reid_dir / f"{session_name}.json").exists()
+
+    decrypted = json.loads(Fernet(key).decrypt(enc_file.read_bytes()))
+    assert decrypted.get("PatientID") == PATIENT_ID
 
 
 def transfer_to_source(

--- a/xnat_ingest/cli/tests/test_cli.py
+++ b/xnat_ingest/cli/tests/test_cli.py
@@ -47,11 +47,6 @@ from xnat_ingest.model.session import ImagingSession
 PATTERN = "{PatientName.family_name}_{PatientName.given_name}_{SeriesDate}.*"
 
 
-DICOM_DEID_SPEC = """
-# Specification for de-identifying DICOM files for project PROJ goes here
-"""
-
-
 @click.command(
     help="""Stages images found in the input directories into separate directories for each
 imaging acquisition session
@@ -1215,6 +1210,10 @@ def test_deidentify_cli_dicom(
     ACCESSION = "ACC001"
     STUDY_UID = "1.2.3.4.5.6.7.8.9.0"
 
+    DICOM_DEID_SPEC = """
+# Specification for de-identifying DICOM files for project PROJ goes here
+"""
+
     # 1. Generate DICOM test data for multiple scan types in subdirectories
     dicoms_dir = tmp_path / "dicoms"
     dicoms_dir.mkdir()
@@ -1335,7 +1334,7 @@ def test_deidentify_cli_dicom_encrypted_reid(
     spec_dir = tmp_path / "spec"
     project_spec_dir = spec_dir / PROJECT_ID
     project_spec_dir.mkdir(parents=True)
-    (project_spec_dir / "medimage@dicom-series").write_text(DICOM_DEID_SPEC)
+    (project_spec_dir / "medimage@dicom-series").write_text("Dummy spec")
 
     output_dir = tmp_path / "deidentified"
     reid_dir = tmp_path / "reid"

--- a/xnat_ingest/cli/tests/test_cli.py
+++ b/xnat_ingest/cli/tests/test_cli.py
@@ -8,10 +8,10 @@ from pathlib import Path
 from unittest.mock import patch
 
 import click
+import pytest
 import xnat4tests  # type: ignore[import-untyped]
 from fileformats.application import Json, Yaml
 from fileformats.medimage import DicomSeries
-from fileformats.medimage.base import MedicalImagingData
 from fileformats.testing import MyFormat, MyFormatGz
 from frametree.core.cli import add_source as dataset_add_source
 from frametree.core.cli import define as dataset_define  # type: ignore[import-untyped]
@@ -1195,36 +1195,20 @@ def test_check_upload_checksum_fail(
     assert "CHECKSUM FAIL" in logs
 
 
-def _mock_dicom_deidentify(
-    self: MedicalImagingData,
-    spec: ty.Any = None,
-    out_dir: ty.Optional[Path] = None,
-) -> tuple:
-    """Stand-in for dicom_deidentify (not yet implemented by the colleague).
-
-    Copies the fileset to out_dir and returns a minimal reid metadata dict
-    containing the original PatientName and PatientID so the tests can assert
-    that PHI values are captured and persisted.
-    """
-    out_dir = Path(out_dir)
-    out_dir.mkdir(parents=True, exist_ok=True)
-    copied = self.copy(out_dir)
-    reid = {
-        "PatientName": str(self.metadata.get("PatientName", "")),
-        "PatientID": str(self.metadata.get("PatientID", "")),
-    }
-    return copied, reid
-
-
+@pytest.mark.xfail(
+    reason=(
+        "Requires ImagingSession.deidentify to be implemented, but can be adapted to "
+        "test the full deidentification pipeline once that is done"
+    ),
+)
 def test_deidentify_cli_dicom(
     cli_runner: ty.Any,
     tmp_path: Path,
 ) -> None:
     """Sort DICOM sessions then run deidentify_cli end-to-end.
 
-    MedicalImagingData.deidentify is mocked (the real implementation will be
-    provided by a colleague).  The test verifies the full pipeline: staging →
-    session loading → spec parsing → deidentification → reid persistence.
+    Verifies the full pipeline: staging → session loading → spec parsing →
+    deidentification → reid persistence.
     """
     PROJECT_ID = "TESTDEIDPROJECT"
     PATIENT_ID = "subject1"
@@ -1269,29 +1253,28 @@ def test_deidentify_cli_dicom(
     assert (staged_dir / session_name).exists(), "Session not staged"
 
     # 3. Project spec mapping DicomSeries to an empty spec dict
+
     spec_dir = tmp_path / "spec"
-    spec_dir.mkdir()
-    (spec_dir / f"{PROJECT_ID}.json").write_text(
-        '{"medimage/dicom-series": DICOM_DEID_SPEC}'
-    )
+    project_spec_dir = spec_dir / PROJECT_ID
+    project_spec_dir.mkdir(parents=True)
+    (project_spec_dir / "medimage@dicom-series").write_text(DICOM_DEID_SPEC)
 
     # 4. Run deidentify_cli with the mock deidentify implementation
     output_dir = tmp_path / "deidentified"
     reid_dir = tmp_path / "reid"
     deid_log = tmp_path / "deid.log"
 
-    with patch.object(MedicalImagingData, "deidentify", _mock_dicom_deidentify):
-        result = cli_runner(
-            deidentify_cli,
-            [
-                str(staged_dir),
-                str(output_dir),
-                str(spec_dir),
-                str(reid_dir),
-                "--raise-errors",
-            ],
-            env={"XINGEST_LOGGERS": f"file info {deid_log};stream info stdout"},
-        )
+    result = cli_runner(
+        deidentify_cli,
+        [
+            str(staged_dir),
+            str(output_dir),
+            str(spec_dir),
+            str(reid_dir),
+            "--raise-errors",
+        ],
+        env={"XINGEST_LOGGERS": f"file info {deid_log};stream info stdout"},
+    )
     assert result.exit_code == 0, show_cli_trace(result)
 
     # 5. Log reports success
@@ -1317,8 +1300,14 @@ def test_deidentify_cli_dicom_encrypted_reid(
     cli_runner: ty.Any,
     tmp_path: Path,
 ) -> None:
-    """Deidentify with --reid-encrypt-key produces a decryptable .json.enc file."""
+    """Deidentify with --reid-encrypt-key produces a decryptable .json.enc file.
+
+    ImagingSession.deidentify is mocked so the test focuses on the encryption
+    logic rather than the deidentification implementation.
+    """
     from cryptography.fernet import Fernet
+    from unittest.mock import MagicMock
+    from xnat_ingest.model.session import ImagingSession
 
     PROJECT_ID = "TESTDEIDENCPROJECT"
     PATIENT_ID = "subject1"
@@ -1344,16 +1333,20 @@ def test_deidentify_cli_dicom_encrypted_reid(
     assert result.exit_code == 0, show_cli_trace(result)
 
     spec_dir = tmp_path / "spec"
-    spec_dir.mkdir()
-    (spec_dir / f"{PROJECT_ID}.json").write_text(
-        '{"medimage/dicom-series": DICOM_DEID_SPEC}'
-    )
+    project_spec_dir = spec_dir / PROJECT_ID
+    project_spec_dir.mkdir(parents=True)
+    (project_spec_dir / "medimage@dicom-series").write_text(DICOM_DEID_SPEC)
 
     output_dir = tmp_path / "deidentified"
     reid_dir = tmp_path / "reid"
     key = Fernet.generate_key()
 
-    with patch.object(MedicalImagingData, "deidentify", _mock_dicom_deidentify):
+    def mock_deidentify(self, dest_dir, **kwargs):
+        mock_session = MagicMock()
+        mock_session.save = MagicMock()
+        return mock_session, {"PatientID": PATIENT_ID}
+
+    with patch.object(ImagingSession, "deidentify", mock_deidentify):
         result = cli_runner(
             deidentify_cli,
             [

--- a/xnat_ingest/model/session.py
+++ b/xnat_ingest/model/session.py
@@ -534,7 +534,7 @@ class ImagingSession:
         self,
         dest_dir: Path,
         project_spec: dict[type[FileSet], ty.Any] = None,
-        copy_mode: FileSet.CopyMode = FileSet.CopyMode.copy,
+        copy_mode: FileSet.CopyMode = FileSet.CopyMode.hardlink_or_copy,
         avoid_clashes: bool = False,
         require_matching_spec: bool = True,
     ) -> tuple[Self, dict[str, ty.Any]]:
@@ -551,7 +551,7 @@ class ImagingSession:
             and the values are arbitrary file-format-specific specifications.
         copy_mode : FileSet.CopyMode, optional
             the mode to use to copy the files that don't need to be deidentified,
-            by default FileSet.CopyMode.copy
+            by default FileSet.CopyMode.hardlink_or_copy
         avoid_clashes : bool, optional
             when copying a file that doesn't need to be deidentified, if a resource
             with the same name already exists in the scan, increment the
@@ -600,9 +600,12 @@ class ImagingSession:
         for scan in self.scans.values():
             for resource_name, resource in scan.resources.items():
                 resource_dest_dir = dest_dir / scan.id / resource_name
-                if getattr(resource.fileset, "contains_phi", False):
+                if not getattr(resource.fileset, "contains_phi", False):
                     deid_resource = resource.fileset.copy(
-                        resource_dest_dir, mode=copy_mode, new_stem=resource_name
+                        resource_dest_dir,
+                        mode=copy_mode,
+                        new_stem=resource_name,
+                        avoid_clashes=True,
                     )
                 else:
                     resource_spec = select_spec(resource.fileset)
@@ -612,7 +615,7 @@ class ImagingSession:
                             "Please provide a project specification for %s in the file format hierarchy to "
                             "deidentify this resource. Returning None and copying the files without "
                             "deidentification, which may lead to PHI being uploaded to XNAT if the fileset "
-                            "contains PHI. Matching specifications found in project spec: %s",
+                            "contains PHI. Matching specifications found in project spec: %s"
                         )
                         msg_vars = (
                             type(resource.fileset).__name__,

--- a/xnat_ingest/model/session.py
+++ b/xnat_ingest/model/session.py
@@ -14,8 +14,9 @@ from pathlib import Path
 import attrs
 import yaml
 from fileformats.core import FileSet, from_mime, from_paths
+from fileformats.core.utils import collate_metadata_series
 from fileformats.application import Yaml
-from fileformats.medimage import DicomCollection, MedicalImage
+from fileformats.medimage import DicomCollection
 from frametree.core.exceptions import FrameTreeDataMatchError
 from frametree.core.frameset import FrameSet
 from tqdm import tqdm
@@ -79,7 +80,6 @@ class ImagingSession:
     def __attrs_post_init__(self) -> None:
         for scan in self.scans.values():
             scan.session = self
-
 
     def __getitem__(self, fieldname: str) -> ty.Any:
         return self.metadata[fieldname]
@@ -533,37 +533,102 @@ class ImagingSession:
     def deidentify(
         self,
         dest_dir: Path,
+        project_spec: dict[type[FileSet], ty.Any] = None,
         copy_mode: FileSet.CopyMode = FileSet.CopyMode.copy,
         avoid_clashes: bool = False,
-    ) -> Self:
+        require_matching_spec: bool = True,
+    ) -> tuple[Self, dict[str, ty.Any]]:
         """Creates a new session with deidentified images
 
         Parameters
         ----------
         dest_dir : Path
             the directory to save the deidentified files into
+        project_spec : dict[type[FileSet], Any], optional
+            a project-specific specification that defines how to deidentify the different
+            file types within the imaging session. The keys of the project spec are
+            the mime-like of the file types (see https://arcanaframework.github.io/fileformats/)
+            and the values are arbitrary file-format-specific specifications.
         copy_mode : FileSet.CopyMode, optional
             the mode to use to copy the files that don't need to be deidentified,
             by default FileSet.CopyMode.copy
+        avoid_clashes : bool, optional
+            when copying a file that doesn't need to be deidentified, if a resource
+            with the same name already exists in the scan, increment the
+            resource name by appending _1, _2 etc. to the name until a unique name is found,
+            by default False
+        require_matching_spec : bool, optional
+            whether to require a matching specification for each fileset, by default True
 
         Returns
         -------
         ImagingSession
             a new session with deidentified images
+        dict[str, Any]
+            a mapping containing the original values of metadata fields that
+            have been removed or modified
         """
+        if project_spec is None:
+            project_spec = {}
+
+        def select_spec(fileset: FileSet) -> ty.Any:
+            """Select the appropriate deidentification specification for the
+            resource based on its file type
+            """
+            matching_specs = {
+                k: v for k, v in project_spec.items() if isinstance(resource.fileset, k)
+            }
+            if not matching_specs:
+                return None
+            elif len(matching_specs) > 1:
+                for k in matching_specs:
+                    if all(issubclass(k, other_k) for other_k in matching_specs):
+                        return matching_specs[k]
+                raise KeyError(
+                    f"Multiple deidentification specifications found for {resource.fileset} "
+                    f"fileset in {scan.id}/{resource_name} resource and none it is ambiguous, "
+                    f" to use. Please provide a more specific project specification for "
+                    f"{type(resource.fileset).__name__} in the "
+                    f"file format hierarchy to disambiguate between the following matching "
+                    f"specifications: {list(matching_specs)}"
+                )
+            return next(iter(matching_specs.values()))
+
         # Create a new session to save the deidentified files into
         deidentified = self.new_empty()
+        reid_series = []
         for scan in self.scans.values():
             for resource_name, resource in scan.resources.items():
                 resource_dest_dir = dest_dir / scan.id / resource_name
-                if not isinstance(resource.fileset, MedicalImage):
+                if getattr(resource.fileset, "contains_phi", False):
                     deid_resource = resource.fileset.copy(
                         resource_dest_dir, mode=copy_mode, new_stem=resource_name
                     )
                 else:
-                    deid_resource = resource.fileset.deidentify(
-                        resource_dest_dir, copy_mode=copy_mode, new_stem=resource_name
+                    resource_spec = select_spec(resource.fileset)
+                    if resource_spec is None:
+                        msg = (
+                            "No deidentification specification found for %s fileset in %s/%s resource. "
+                            "Please provide a project specification for %s in the file format hierarchy to "
+                            "deidentify this resource. Returning None and copying the files without "
+                            "deidentification, which may lead to PHI being uploaded to XNAT if the fileset "
+                            "contains PHI. Matching specifications found in project spec: %s",
+                        )
+                        msg_vars = (
+                            type(resource.fileset).__name__,
+                            scan.id,
+                            resource_name,
+                            type(resource.fileset).__name__,
+                            list(project_spec),
+                        )
+                        if require_matching_spec:
+                            raise KeyError(msg % msg_vars)
+                        else:
+                            logger.warning(msg, *msg_vars)
+                    deid_resource, reid_mdata = resource.fileset.deidentify(
+                        resource_dest_dir, spec=resource_spec
                     )
+                    reid_series.append(reid_mdata)
                 deidentified.add_resource(
                     scan.id,
                     scan.type,
@@ -571,7 +636,7 @@ class ImagingSession:
                     deid_resource,
                     avoid_clashes=avoid_clashes,
                 )
-        return deidentified
+        return deidentified, collate_metadata_series(reid_series)
 
     def associate_files(
         self,
@@ -937,7 +1002,9 @@ class ImagingSession:
         session_dir = dest_dir / session_dirname
         session_dir.mkdir(parents=True, exist_ok=True)
         for scan in tqdm(self.scans.values(), f"Staging sessions to {session_dir}"):
-            saved_scan = scan.save(session_dir, copy_mode=copy_mode, collation_map=collation_map)
+            saved_scan = scan.save(
+                session_dir, copy_mode=copy_mode, collation_map=collation_map
+            )
             saved_scan.session = saved
             saved.scans[saved_scan.id] = saved_scan
         for resource in self.session_resources.values():

--- a/xnat_ingest/model/session.py
+++ b/xnat_ingest/model/session.py
@@ -629,7 +629,7 @@ class ImagingSession:
                         else:
                             logger.warning(msg, *msg_vars)
                     deid_resource, reid_mdata = resource.fileset.deidentify(
-                        resource_dest_dir, spec=resource_spec
+                        out_dir=resource_dest_dir, spec=resource_spec
                     )
                     reid_series.append(reid_mdata)
                 deidentified.add_resource(

--- a/xnat_ingest/model/tests/test_session.py
+++ b/xnat_ingest/model/tests/test_session.py
@@ -170,7 +170,7 @@ def raw_frameset(tmp_path: Path) -> FrameSet:
 # )
 def test_session_select_resources(
     imaging_session: ImagingSession, dataset: FrameSet, tmp_path: Path
-):
+) -> None:
 
     assoc_dir = tmp_path / "assoc"
     assoc_dir.mkdir()
@@ -225,7 +225,9 @@ def test_session_select_resources(
     )
 
 
-def test_session_save_roundtrip(tmp_path: Path, imaging_session: ImagingSession):
+def test_session_save_roundtrip(
+    tmp_path: Path, imaging_session: ImagingSession
+) -> None:
 
     # Save imaging sessions to a temporary directory
     saved, _ = imaging_session.save(tmp_path)
@@ -255,7 +257,7 @@ def test_session_save_roundtrip(tmp_path: Path, imaging_session: ImagingSession)
     # assert loaded_no_manifest == saved
 
 
-def test_stage_raw_data_directly(raw_frameset: FrameSet, tmp_path: Path):
+def test_stage_raw_data_directly(raw_frameset: FrameSet, tmp_path: Path) -> None:
 
     raw_data_dir = tmp_path / "raw"
     raw_data_dir.mkdir()
@@ -510,7 +512,10 @@ def test_session_resource_save_roundtrip(tmp_path: Path) -> None:
     reloaded = ImagingSession.load(session_dir)
 
     assert "radiology-doc-report" in reloaded.session_resources
-    assert reloaded.session_resources["radiology-doc-report"].checksums == saved.session_resources["radiology-doc-report"].checksums
+    assert (
+        reloaded.session_resources["radiology-doc-report"].checksums
+        == saved.session_resources["radiology-doc-report"].checksums
+    )
 
 
 def test_id_escape(tmp_path: Path) -> None:
@@ -540,3 +545,119 @@ def test_id_escape(tmp_path: Path) -> None:
 
     assert len(sessions) == 1
     assert sessions[0].subject_id == "INSTRUMENT_SURNAME_FIRST_NAME"
+
+
+# ---------------------------------------------------------------------------
+# ImagingSession.deidentify tests
+# ---------------------------------------------------------------------------
+
+DEIDENTIFY_REID_MDATA = {"PatientName": "John Doe", "DOB": "19800101"}
+
+
+def _make_deid_fileset(seed: int, expected_reid: dict) -> File:
+    """Return a File instance with an injected deidentify() method for testing.
+
+    The instance has no ``contains_phi`` attribute so session.deidentify() routes
+    it through the spec-based branch rather than the plain copy branch.
+    """
+    f = File.sample(seed=seed)
+
+    def _deidentify(out_dir: Path, spec: ty.Any = None) -> tuple:
+        out_dir = Path(out_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        return f.copy(out_dir), dict(expected_reid)
+
+    f.deidentify = _deidentify
+    return f
+
+
+def test_deidentify_empty_session(tmp_path: Path) -> None:
+    session = ImagingSession(
+        project_id="PROJ", subject_id="SUBJ", visit_id="SESS", scans=[]
+    )
+    deid_session, reid_mdata = session.deidentify(tmp_path / "dest")
+    assert deid_session.project_id == "PROJ"
+    assert deid_session.scans == {}
+    assert reid_mdata == {}
+
+
+def test_deidentify_contains_phi_copies_files(
+    imaging_session: ImagingSession, tmp_path: Path
+) -> None:
+    """MedicalImagingData (contains_phi=True) is copied as-is; no reid metadata collected."""
+    deid_session, reid_mdata = imaging_session.deidentify(tmp_path / "dest")
+
+    assert set(deid_session.scans) == set(imaging_session.scans)
+    assert reid_mdata == {}
+    for scan in deid_session.scans.values():
+        for resource in scan.resources.values():
+            for fspath in resource.fileset.fspaths:
+                assert fspath.exists()
+
+
+def test_deidentify_collects_reid_metadata(tmp_path: Path) -> None:
+    """deidentify() returns reid metadata from resources that implement deidentify."""
+    f = _make_deid_fileset(seed=1, expected_reid=DEIDENTIFY_REID_MDATA)
+    session = ImagingSession(
+        project_id="PROJ",
+        subject_id="SUBJ",
+        visit_id="SESS",
+        scans=[ImagingScan(id="1", type="test-scan", resources={"FILE": f})],
+    )
+    deid_session, reid_mdata = session.deidentify(
+        tmp_path / "dest", project_spec={File: {}}
+    )
+    assert reid_mdata == DEIDENTIFY_REID_MDATA
+    assert "1" in deid_session.scans
+
+
+def test_deidentify_missing_spec_raises(tmp_path: Path) -> None:
+    """Empty project_spec with require_matching_spec=True raises KeyError."""
+    f = _make_deid_fileset(seed=1, expected_reid=DEIDENTIFY_REID_MDATA)
+    session = ImagingSession(
+        project_id="PROJ",
+        subject_id="SUBJ",
+        visit_id="SESS",
+        scans=[ImagingScan(id="1", type="test-scan", resources={"FILE": f})],
+    )
+    with pytest.raises(KeyError):
+        session.deidentify(
+            tmp_path / "dest", project_spec={}, require_matching_spec=True
+        )
+
+
+def test_deidentify_missing_spec_warns(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Empty project_spec with require_matching_spec=False logs a warning and proceeds."""
+    f = _make_deid_fileset(seed=1, expected_reid=DEIDENTIFY_REID_MDATA)
+    session = ImagingSession(
+        project_id="PROJ",
+        subject_id="SUBJ",
+        visit_id="SESS",
+        scans=[ImagingScan(id="1", type="test-scan", resources={"FILE": f})],
+    )
+    with caplog.at_level(logging.WARNING, logger="xnat-ingest"):
+        deid_session, reid_mdata = session.deidentify(
+            tmp_path / "dest", project_spec={}, require_matching_spec=False
+        )
+    assert "No deidentification specification" in caplog.text
+    assert "1" in deid_session.scans
+    assert reid_mdata == DEIDENTIFY_REID_MDATA
+
+
+def test_deidentify_merges_reid_metadata_across_resources(tmp_path: Path) -> None:
+    """Reid metadata from multiple resources is collated into a single dict."""
+    f1 = _make_deid_fileset(seed=1, expected_reid={"PatientName": "Alice"})
+    f2 = _make_deid_fileset(seed=2, expected_reid={"DOB": "19901201"})
+    session = ImagingSession(
+        project_id="PROJ",
+        subject_id="SUBJ",
+        visit_id="SESS",
+        scans=[
+            ImagingScan(id="1", type="scan-a", resources={"FILE": f1}),
+            ImagingScan(id="2", type="scan-b", resources={"FILE": f2}),
+        ],
+    )
+    _, reid_mdata = session.deidentify(tmp_path / "dest", project_spec={File: {}})
+    assert reid_mdata == {"PatientName": "Alice", "DOB": "19901201"}

--- a/xnat_ingest/model/tests/test_session.py
+++ b/xnat_ingest/model/tests/test_session.py
@@ -555,17 +555,19 @@ DEIDENTIFY_REID_MDATA = {"PatientName": "John Doe", "DOB": "19800101"}
 
 
 def _make_deid_fileset(seed: int, expected_reid: dict) -> File:
-    """Return a File instance with an injected deidentify() method for testing.
+    """Return a File instance with contains_phi=True and an injected deidentify().
 
-    The instance has no ``contains_phi`` attribute so session.deidentify() routes
-    it through the spec-based branch rather than the plain copy branch.
+    Setting contains_phi=True routes it through the deidentify branch in
+    session.deidentify().  The injected method is called as an unbound function
+    (instance attribute), so it receives no implicit ``self``.
     """
     f = File.sample(seed=seed)
+    f.contains_phi = True
 
-    def _deidentify(out_dir: Path, spec: ty.Any = None) -> tuple:
-        out_dir = Path(out_dir)
-        out_dir.mkdir(parents=True, exist_ok=True)
-        return f.copy(out_dir), dict(expected_reid)
+    def _deidentify(spec: ty.Any = None, out_dir: ty.Optional[Path] = None) -> tuple:
+        dest = Path(out_dir)
+        dest.mkdir(parents=True, exist_ok=True)
+        return f.copy(dest), dict(expected_reid)
 
     f.deidentify = _deidentify
     return f
@@ -581,13 +583,17 @@ def test_deidentify_empty_session(tmp_path: Path) -> None:
     assert reid_mdata == {}
 
 
-def test_deidentify_contains_phi_copies_files(
-    imaging_session: ImagingSession, tmp_path: Path
-) -> None:
-    """MedicalImagingData (contains_phi=True) is copied as-is; no reid metadata collected."""
-    deid_session, reid_mdata = imaging_session.deidentify(tmp_path / "dest")
-
-    assert set(deid_session.scans) == set(imaging_session.scans)
+def test_deidentify_no_phi_copies_files(tmp_path: Path) -> None:
+    """Resources without contains_phi are copied as-is; no reid metadata collected."""
+    f = File.sample(seed=1)  # no contains_phi attr → getattr returns False → copy path
+    session = ImagingSession(
+        project_id="PROJ",
+        subject_id="SUBJ",
+        visit_id="SESS",
+        scans=[ImagingScan(id="1", type="test-scan", resources={"FILE": f})],
+    )
+    deid_session, reid_mdata = session.deidentify(tmp_path / "dest")
+    assert "1" in deid_session.scans
     assert reid_mdata == {}
     for scan in deid_session.scans.values():
         for resource in scan.resources.values():


### PR DESCRIPTION
Adds the following functionality:

* Read project-specific deidentification specifications from spec_dir
  * Specs for different file-types are stored in separate files project-specific sub-dirs, named using their mime-like strings with the '/' replaced with a '@', e.g. image@png, medimage@dicom-series
* Write original values of modified fields to JSON dicts
  * Optionally encrypt the JSON files if key is provided