### PR TITLE
SessionOnlyListing for resource uploads no requiring full triplet name

### DIFF
--- a/xnat_ingest/api/sort_.py
+++ b/xnat_ingest/api/sort_.py
@@ -253,13 +253,14 @@ def sort(
 
 
 def list_session_dirs(sorted_dir: Path) -> list[Path]:
-    """List the session directories in the sorted directory, excluding any directories that start with '__'"""
+    """List the session directories in the sorted directory, excluding any directories that start with '__'.
 
+    Includes both dotted dirs (PROJ.SUBJ.VISIT) and no-dot dirs (session label only).
+    """
     return [
         p
         for p in Path(sorted_dir).iterdir()
         if p.is_dir()
         and not p.name.startswith("__")
         and not p.name.endswith("__")
-        and "." in p.name
     ]

--- a/xnat_ingest/api/upload_.py
+++ b/xnat_ingest/api/upload_.py
@@ -17,6 +17,7 @@ from xnat.exceptions import XNATResponseError
 from xnat_ingest.helpers.remotes import (
     LocalSessionListing,
     SessionListing,
+    SessionOnlyListing,
     calculate_checksums,
     dir_older_than,
     get_xnat_checksums,
@@ -27,6 +28,7 @@ from xnat_ingest.helpers.remotes import (
 
 from ..helpers.arg_types import StoreCredentials, UploadMethod
 from ..helpers.logging import logger
+from ..model.resource import ImagingResource
 from ..model.session import ImagingSession
 from . import list_session_dirs
 
@@ -129,7 +131,10 @@ def upload(
             sessions = []
             for session_dir in list_session_dirs(input_dir):
                 if dir_older_than(session_dir, wait_period):
-                    sessions.append(LocalSessionListing(session_dir))
+                    if "." in session_dir.name:
+                        sessions.append(LocalSessionListing(session_dir))
+                    else:
+                        sessions.append(SessionOnlyListing(session_dir))
                 else:
                     logger.info(
                         "Skipping '%s' session as it has been modified recently",
@@ -165,6 +170,40 @@ def upload(
                         session_listing.name,
                     )
                     continue  # skip as session already exists
+
+                if isinstance(session_listing, SessionOnlyListing):
+                    xsession = session_listing.find_xnat_session(xnat_repo.connection)
+                    if xsession is None:
+                        raise RuntimeError(
+                            f"No XNAT session found with label '{session_listing.session_id}'. "
+                            "Ensure the session exists on XNAT before uploading session-only resources."
+                        )
+                    for resource_name in session_listing.resource_paths:
+                        resource = ImagingResource.load(
+                            session_listing.cache_path / resource_name,
+                            require_manifest=require_manifest,
+                            check_checksums=check_checksums,
+                        )
+                        uri = f"{xsession.uri}/resources/{resource.name}"
+                        xnat_repo.connection.put(uri)
+                        xnat_repo.connection.clearcache()
+                        xresource = xnat_repo.connection.create_object(uri)
+                        xresource.upload_dir(
+                            session_listing.cache_path / resource.name,
+                            method=UploadMethod.select_method(
+                                methods, type(resource.fileset)
+                            ),
+                        )
+                        logger.info(
+                            "Uploaded '%s' to session '%s'",
+                            resource.name,
+                            session_listing.session_id,
+                        )
+                    logger.info(
+                        "Successfully uploaded all resources to '%s'",
+                        session_listing.session_id,
+                    )
+                    continue
 
                 session = ImagingSession.load(
                     session_listing.cache_path,

--- a/xnat_ingest/helpers/remotes.py
+++ b/xnat_ingest/helpers/remotes.py
@@ -129,6 +129,60 @@ class LocalSessionListing(SessionListing):
 
 
 @attrs.define
+class SessionOnlyListing:
+    """A staging directory named by session label only (no project.subject.visit structure).
+
+    Used when uploading resources directly to an existing XNAT session identified only by
+    its label. The label must be globally unique across all projects accessible to the upload
+    account — an error is raised if multiple sessions match.
+    """
+
+    fspath: Path
+
+    @property
+    def cache_path(self) -> Path:
+        return self.fspath
+
+    @property
+    def name(self) -> str:
+        return self.fspath.name
+
+    @property
+    def session_id(self) -> str:
+        return self.fspath.name
+
+    @property
+    def resource_paths(self) -> set[str]:
+        return {
+            item.name
+            for item in self.fspath.iterdir()
+            if item.is_dir() and "." not in item.name
+        }
+
+    def find_xnat_session(self, connection: xnat.XNATSession) -> ty.Any:
+        """Look up an existing XNAT session by label across all accessible projects.
+
+        Returns None if not found, raises RuntimeError if multiple sessions match.
+        """
+        matches = [
+            e for e in connection.experiments.values() if e.label == self.session_id
+        ]
+        if len(matches) > 1:
+            raise RuntimeError(
+                f"Multiple XNAT sessions found with label '{self.session_id}'. "
+                "Session labels must be globally unique for session-only uploads."
+            )
+        return matches[0] if matches else None
+
+    def all_uploaded(self, connection: xnat.XNATSession) -> bool:
+        xsession = self.find_xnat_session(connection)
+        if xsession is None:
+            return False
+        uploaded = {r.label for r in xsession.resources.values()}
+        return uploaded.issuperset(self.resource_paths)
+
+
+@attrs.define
 class S3SessionListing(SessionListing):
 
     name: str

--- a/xnat_ingest/helpers/tests/test_remotes.py
+++ b/xnat_ingest/helpers/tests/test_remotes.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from xnat_ingest.api.sort_ import list_session_dirs
+from xnat_ingest.helpers.remotes import SessionOnlyListing
+
+
+def test_list_session_dirs_includes_no_dot_dirs(tmp_path: Path) -> None:
+    (tmp_path / "PROJ.SUBJ.VISIT").mkdir()
+    (tmp_path / "P000065").mkdir()
+    (tmp_path / "__build__").mkdir()
+    names = {d.name for d in list_session_dirs(tmp_path)}
+    assert "PROJ.SUBJ.VISIT" in names
+    assert "P000065" in names
+    assert "__build__" not in names
+
+
+def test_session_only_listing_resource_paths(tmp_path: Path) -> None:
+    session_dir = tmp_path / "P000065"
+    (session_dir / "my-report").mkdir(parents=True)
+    (session_dir / "another-resource").mkdir()
+    listing = SessionOnlyListing(session_dir)
+    assert listing.resource_paths == {"my-report", "another-resource"}
+
+
+def test_find_xnat_session_raises_on_multiple_matches(tmp_path: Path) -> None:
+    listing = SessionOnlyListing(tmp_path / "P000065")
+    connection = MagicMock()
+    connection.experiments.values.return_value = [
+        MagicMock(label="P000065"),
+        MagicMock(label="P000065"),
+    ]
+    with pytest.raises(RuntimeError, match="Multiple XNAT sessions"):
+        listing.find_xnat_session(connection)


### PR DESCRIPTION
Allows us to upload resources named just by the session label. Will find XNAT sessions with that label, or otherwise raise an error.

Tested upload from a dir with no '.' and the resource uploads to the session with that label.