### PR TITLE
fix entrypoint: base_cli → cli

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ all = ["xnat-ingest[dev,test]"]
 repository = "https://github.com/Australian-Imaging-Service/xnat_ingest"
 
 [project.scripts]
-xnat-ingest = "xnat_ingest.cli:base_cli"
+xnat-ingest = "xnat_ingest.cli:cli"
 
 [tool.hatch.version]
 source = "vcs"


### PR DESCRIPTION
Error when deploying image from docker, change in base_cli causes it to crash. This should fix that:

```  Traceback (most recent call last):
    File "/usr/local/bin/xnat-ingest", line 5, in <module>
      from xnat_ingest.cli import base_cli
  ImportError: cannot import name 'base_cli' from 'xnat_ingest.cli' (/usr/local/lib/python3.14/dist-packages/xnat_ingest/cli/__init__.py)
  
  ```