### PR TITLE
invalid assigned files uid's check to avoid duplication

### DIFF
--- a/xnat_ingest/api/assign_api.py
+++ b/xnat_ingest/api/assign_api.py
@@ -1,3 +1,4 @@
+import json
 import shutil
 import traceback
 from pathlib import Path
@@ -6,10 +7,38 @@ from fileformats.core import FileSet
 from tqdm import tqdm
 
 from ..helpers.logging import logger
+from ..helpers.metadata import Metadata
 from ..helpers.remotes import LocalSessionListing, list_session_dirs
 from ..model.session import ImagingSession
 
 INVALID_DIRNAME = "__invalid__"
+
+
+def _existing_invalid_uids(invalid_dir: Path) -> set[str]:
+    """Return the set of source UIDs already saved under __invalid__/.
+
+    Each subdirectory's __METADATA__.json is checked for the ``__uid__`` key
+    that ``ImagingSession.save()`` writes.  Directories whose metadata can't
+    be read are silently skipped.
+    """
+    uids: set[str] = set()
+    if not invalid_dir.is_dir():
+        return uids
+    for session_dir in invalid_dir.iterdir():
+        if not session_dir.is_dir():
+            continue
+        meta_path = session_dir / Metadata.FNAME
+        if not meta_path.exists():
+            continue
+        try:
+            with open(meta_path) as f:
+                meta = json.load(f)
+            uid = meta.get(ImagingSession.UID_METADATA_KEY)
+            if uid is not None:
+                uids.add(uid)
+        except (json.JSONDecodeError, OSError):
+            continue
+    return uids
 
 
 def assign(
@@ -77,6 +106,8 @@ def assign(
     # Ensure the output and reid directories exist
     output_dir.mkdir(parents=True, exist_ok=True)
 
+    invalid_dir = output_dir / INVALID_DIRNAME
+    already_invalid = _existing_invalid_uids(invalid_dir)
     errors: list[str] = []
 
     for session_listing in tqdm(
@@ -99,14 +130,24 @@ def assign(
             )
 
             if missing_ids:
+                if session.uid in already_invalid:
+                    logger.warning(
+                        "Skipping '%s' — already saved as invalid (uid=%s). "
+                        "Manually review/fix and remove from '%s' to re-process.",
+                        session_listing.name,
+                        session.uid,
+                        invalid_dir,
+                    )
+                    continue
                 msg = (
                     f"Could not resolve project/subject/session IDs for '{session_listing.name}', "
                     f"due to missing metadata fields {list(missing_ids)}. "
-                    f"Saved to '{output_dir}/{INVALID_DIRNAME}/{session.name}' for manual review instead"
+                    f"Saved to '{invalid_dir}/{session.name}' for manual review instead"
                 )
                 logger.error(msg)
                 errors.append(msg)
-            dest_dir = (output_dir / INVALID_DIRNAME) if missing_ids else output_dir
+                already_invalid.add(session.uid)
+            dest_dir = invalid_dir if missing_ids else output_dir
             session.save(
                 dest_dir=dest_dir,
                 copy_mode=copy_mode,

--- a/xnat_ingest/api/tests/test_assign.py
+++ b/xnat_ingest/api/tests/test_assign.py
@@ -347,3 +347,49 @@ def test_assign_end_to_end_unresolvable_project_field_goes_to_invalid_dir(
 
     reloaded = ImagingSession.load(session_dirs[0])
     assert reloaded.invalid_ids
+
+
+def test_assign_skips_duplicate_invalid_sessions(
+    dicom_dir: Path, tmp_path: Path
+) -> None:
+    """Running assign twice on the same unresolvable session should not create
+    a second directory in __invalid__."""
+    grouped_dir = tmp_path / "grouped"
+    grouped_dir.mkdir()
+    group_errors = group(
+        input_paths=[str(dicom_dir)],
+        output_dir=grouped_dir,
+        datatypes=[DicomSeries],
+        session=[IDSpec("StudyInstanceUID", "medimage/dicom-collection")],
+        scan=[IDSpec("SeriesNumber", "medimage/dicom-collection")],
+        resource=[IDSpec("ImageType[2:]", "medimage/dicom-collection")],
+    )
+    assert group_errors == []
+
+    output_dir = tmp_path / "assigned"
+    output_dir.mkdir()
+
+    errors1 = assign(
+        input_dir=grouped_dir,
+        output_dir=output_dir,
+        project_field="NonExistentField",
+        subject_field=SUBJECT_FIELD,
+        session_field=SESSION_FIELD,
+    )
+    assert len(errors1) == 1
+    invalid_dir = output_dir / INVALID_DIRNAME
+    entries_after_first = list(invalid_dir.iterdir())
+    assert len(entries_after_first) == 1
+
+    # Second run should skip
+    errors2 = assign(
+        input_dir=grouped_dir,
+        output_dir=output_dir,
+        project_field="NonExistentField",
+        subject_field=SUBJECT_FIELD,
+        session_field=SESSION_FIELD,
+    )
+    assert errors2 == []
+    entries_after_second = list(invalid_dir.iterdir())
+    assert len(entries_after_second) == 1
+    assert entries_after_second[0] == entries_after_first[0]


### PR DESCRIPTION
Fix #115. Instead of recreating a new invalid file on each run of assign, instead look at the UID's to check if one already exists and log that it needs to be checked.

This would be fine if manually running the pipeline, but for automatic assignment it will bloat the `__invalid__` dir. 