### PR TITLE
**BREAKING CHANGE**: Adds `--ignore` option to `group` to specify which files can be safely ignored

### DIFF
--- a/docs/source/developer/file_formats.rst
+++ b/docs/source/developer/file_formats.rst
@@ -13,8 +13,8 @@ a format-specific branch for each one.
 Grouping files into resources
 ----------------------------------
 
-``group``'s ``--datatype`` option (see :doc:`/cli`) is a FileFormats MIME-like
-identifier (or a ``|``-separated union of several) that says which types of file to
+``group``'s ``--datatype`` option (see :doc:`/cli`) is a `FileFormats MIME-like
+identifier <https://arcanaframework.github.io/fileformats/mime.html>`_ (or a ``|``-separated union of several) that says which types of file to
 look for in the input paths at all. Within a matched session, ``--scan``/
 ``--resource`` (:class:`~xnat_ingest.helpers.arg_types.IDSpec`) then decide which
 scan and resource each file belongs to, based on values read out of the file's own

--- a/xnat_ingest/api/group_api.py
+++ b/xnat_ingest/api/group_api.py
@@ -25,7 +25,8 @@ def group(
     raise_errors: bool = False,
     copy_mode: FileSet.CopyMode = FileSet.CopyMode.hardlink_or_copy,
     collation_map: dict[ty.Type[FileSet], FileSet.CopyCollation] | None = None,
-    ignore: str | None = None,
+    ignore_paths: list[str] | None = None,
+    ignore_types: list[type[FileSet]] = None,
     wait_period: int = 0,
     avoid_clashes: bool = True,
     recursive: bool = False,
@@ -68,9 +69,12 @@ def group(
     collation_map: dict[ty.Type[FileSet], FileSet.CopyCollation] | None
         A mapping of FileSet types to CopyCollation objects that specify how to collate files of that type when saving the
         sessions. If None, the default collation behavior for each FileSet type will be used.
-    ignore: str | None
-        A regular expression to match paths that should be ignored when grouping files into sessions. If None, no paths will be ignored.
+    ignore_paths: list[str] | None
+        Regular expressions to match paths that should be ignored when grouping files into sessions. If None, no paths will be ignored.
         To ignore all paths by default, use ".*" as the value for this parameter.
+    ignore_types: list[type[FileSet]] | None
+        Datatypes that should be ignored when grouping files into sessions. If None, paths that aren't recognised as part of the
+        requested datatypes or filtered using ignore_paths will raise an error
     wait_period: int
         If provided, this is the number of seconds that must have passed since the last modification time of the session before
         it will be staged. This can be used to avoid staging sessions that are still being modified or created.
@@ -92,13 +96,14 @@ def group(
 
     sessions = ImagingSession.from_paths(
         files_path=input_paths,
-        datatypes=datatypes,
+        datatypes=datatypes + ignore_types,
         session_field=session,
         scan_field=scan,
         resource_field=resource,
         recursive=recursive,
         avoid_clashes=avoid_clashes,
-        ignore=ignore,
+        ignore_paths=ignore_paths,
+        ignore_types=ignore_types,
         path_metadata_regex=path_metadata_regex,
     )
 

--- a/xnat_ingest/api/group_api.py
+++ b/xnat_ingest/api/group_api.py
@@ -26,7 +26,7 @@ def group(
     copy_mode: FileSet.CopyMode = FileSet.CopyMode.hardlink_or_copy,
     collation_map: dict[ty.Type[FileSet], FileSet.CopyCollation] | None = None,
     ignore_paths: list[str] | None = None,
-    ignore_types: list[type[FileSet]] = None,
+    ignore_types: list[type[FileSet]] = (),
     wait_period: int = 0,
     avoid_clashes: bool = True,
     recursive: bool = False,
@@ -96,7 +96,7 @@ def group(
 
     sessions = ImagingSession.from_paths(
         files_path=input_paths,
-        datatypes=datatypes + ignore_types,
+        datatypes=datatypes,
         session_field=session,
         scan_field=scan,
         resource_field=resource,

--- a/xnat_ingest/api/group_api.py
+++ b/xnat_ingest/api/group_api.py
@@ -25,6 +25,7 @@ def group(
     raise_errors: bool = False,
     copy_mode: FileSet.CopyMode = FileSet.CopyMode.hardlink_or_copy,
     collation_map: dict[ty.Type[FileSet], FileSet.CopyCollation] | None = None,
+    ignore: str | None = None,
     wait_period: int = 0,
     avoid_clashes: bool = True,
     recursive: bool = False,
@@ -64,6 +65,12 @@ def group(
     copy_mode: FileSet.CopyMode
         The copy mode to use when saving the sessions. This determines whether files are copied, moved or symlinked when
         saving the sessions to the staging directory.
+    collation_map: dict[ty.Type[FileSet], FileSet.CopyCollation] | None
+        A mapping of FileSet types to CopyCollation objects that specify how to collate files of that type when saving the
+        sessions. If None, the default collation behavior for each FileSet type will be used.
+    ignore: str | None
+        A regular expression to match paths that should be ignored when grouping files into sessions. If None, no paths will be ignored.
+        To ignore all paths by default, use ".*" as the value for this parameter.
     wait_period: int
         If provided, this is the number of seconds that must have passed since the last modification time of the session before
         it will be staged. This can be used to avoid staging sessions that are still being modified or created.
@@ -91,6 +98,7 @@ def group(
         resource_field=resource,
         recursive=recursive,
         avoid_clashes=avoid_clashes,
+        ignore=ignore,
         path_metadata_regex=path_metadata_regex,
     )
 

--- a/xnat_ingest/api/tests/test_group.py
+++ b/xnat_ingest/api/tests/test_group.py
@@ -2,6 +2,7 @@ import shutil
 from pathlib import Path
 
 import pytest
+from fileformats.application import Json
 from fileformats.core.exceptions import FormatRecognitionError
 from fileformats.medimage import DicomSeries
 from medimages4tests.dummy.dicom.pet.wholebody.siemens.biograph_vision.vr20b import (
@@ -105,7 +106,7 @@ def test_group_collects_errors_without_raising(tmp_path: Path) -> None:
     assert errors == []
 
 
-def test_group_unrecognised_file_raises_without_ignore(
+def test_group_unrecognised_file_raises_without_ignore_paths(
     dicom_dir: Path, tmp_path: Path
 ) -> None:
     output_dir = tmp_path / "grouped"
@@ -125,7 +126,7 @@ def test_group_unrecognised_file_raises_without_ignore(
         )
 
 
-def test_group_ignore_skips_matching_unrecognised_files(
+def test_group_ignore_paths_skips_matching_unrecognised_files(
     dicom_dir: Path, tmp_path: Path
 ) -> None:
     output_dir = tmp_path / "grouped"
@@ -141,7 +142,7 @@ def test_group_ignore_skips_matching_unrecognised_files(
         session=SESSION_FIELD,
         scan=SCAN_FIELD,
         resource=RESOURCE_FIELD,
-        ignore=r"notes\.txt",
+        ignore_paths=[r"notes\.txt"],
     )
 
     assert errors == []
@@ -151,7 +152,7 @@ def test_group_ignore_skips_matching_unrecognised_files(
     assert len(session_dirs) == 1
 
 
-def test_group_ignore_pattern_not_matching_still_raises(
+def test_group_ignore_paths_pattern_not_matching_still_raises(
     dicom_dir: Path, tmp_path: Path
 ) -> None:
     output_dir = tmp_path / "grouped"
@@ -168,7 +169,74 @@ def test_group_ignore_pattern_not_matching_still_raises(
             session=SESSION_FIELD,
             scan=SCAN_FIELD,
             resource=RESOURCE_FIELD,
-            ignore=r"unrelated-pattern",
+            ignore_paths=[r"unrelated-pattern"],
+        )
+
+
+def test_group_ignore_types_excludes_recognised_but_unwanted_files(
+    dicom_dir: Path, tmp_path: Path
+) -> None:
+    output_dir = tmp_path / "grouped"
+    output_dir.mkdir()
+    input_dir = tmp_path / "input"
+    shutil.copytree(dicom_dir, input_dir)
+    (input_dir / "notes.json").write_text("{}")
+
+    errors = group(
+        input_paths=[str(input_dir)],
+        output_dir=output_dir,
+        datatypes=[DicomSeries],
+        session=SESSION_FIELD,
+        scan=SCAN_FIELD,
+        resource=RESOURCE_FIELD,
+        ignore_types=[Json],
+    )
+
+    assert errors == []
+    session_dirs = [
+        d for d in output_dir.iterdir() if d.is_dir() and d.name != BUILD_NAME_DEFAULT
+    ]
+    assert len(session_dirs) == 1
+    scan_dir = next(d for d in session_dirs[0].iterdir() if d.is_dir())
+    resource_dir = next(d for d in scan_dir.iterdir() if d.is_dir())
+    assert not list(resource_dir.rglob("notes.json"))
+
+
+def test_group_without_ignore_types_raises_on_recognised_extra_type(
+    dicom_dir: Path, tmp_path: Path
+) -> None:
+    output_dir = tmp_path / "grouped"
+    output_dir.mkdir()
+    input_dir = tmp_path / "input"
+    shutil.copytree(dicom_dir, input_dir)
+    (input_dir / "notes.json").write_text("{}")
+
+    with pytest.raises(FormatRecognitionError, match="notes.json"):
+        group(
+            input_paths=[str(input_dir)],
+            output_dir=output_dir,
+            datatypes=[DicomSeries],
+            session=SESSION_FIELD,
+            scan=SCAN_FIELD,
+            resource=RESOURCE_FIELD,
+        )
+
+
+def test_group_ignore_types_contradicting_datatype_raises(
+    dicom_dir: Path, tmp_path: Path
+) -> None:
+    output_dir = tmp_path / "grouped"
+    output_dir.mkdir()
+
+    with pytest.raises(ValueError, match="listed for both"):
+        group(
+            input_paths=[str(dicom_dir)],
+            output_dir=output_dir,
+            datatypes=[DicomSeries],
+            session=SESSION_FIELD,
+            scan=SCAN_FIELD,
+            resource=RESOURCE_FIELD,
+            ignore_types=[DicomSeries],
         )
 
 

--- a/xnat_ingest/api/tests/test_group.py
+++ b/xnat_ingest/api/tests/test_group.py
@@ -1,6 +1,8 @@
+import shutil
 from pathlib import Path
 
 import pytest
+from fileformats.core.exceptions import FormatRecognitionError
 from fileformats.medimage import DicomSeries
 from medimages4tests.dummy.dicom.pet.wholebody.siemens.biograph_vision.vr20b import (
     get_image as get_pet_image,
@@ -101,6 +103,73 @@ def test_group_collects_errors_without_raising(tmp_path: Path) -> None:
 
     # No files found, so no sessions and no errors either
     assert errors == []
+
+
+def test_group_unrecognised_file_raises_without_ignore(
+    dicom_dir: Path, tmp_path: Path
+) -> None:
+    output_dir = tmp_path / "grouped"
+    output_dir.mkdir()
+    input_dir = tmp_path / "input"
+    shutil.copytree(dicom_dir, input_dir)
+    (input_dir / "notes.txt").write_text("not a recognised format")
+
+    with pytest.raises(FormatRecognitionError, match="notes.txt"):
+        group(
+            input_paths=[str(input_dir)],
+            output_dir=output_dir,
+            datatypes=[DicomSeries],
+            session=SESSION_FIELD,
+            scan=SCAN_FIELD,
+            resource=RESOURCE_FIELD,
+        )
+
+
+def test_group_ignore_skips_matching_unrecognised_files(
+    dicom_dir: Path, tmp_path: Path
+) -> None:
+    output_dir = tmp_path / "grouped"
+    output_dir.mkdir()
+    input_dir = tmp_path / "input"
+    shutil.copytree(dicom_dir, input_dir)
+    (input_dir / "notes.txt").write_text("not a recognised format")
+
+    errors = group(
+        input_paths=[str(input_dir)],
+        output_dir=output_dir,
+        datatypes=[DicomSeries],
+        session=SESSION_FIELD,
+        scan=SCAN_FIELD,
+        resource=RESOURCE_FIELD,
+        ignore=r"notes\.txt",
+    )
+
+    assert errors == []
+    session_dirs = [
+        d for d in output_dir.iterdir() if d.is_dir() and d.name != BUILD_NAME_DEFAULT
+    ]
+    assert len(session_dirs) == 1
+
+
+def test_group_ignore_pattern_not_matching_still_raises(
+    dicom_dir: Path, tmp_path: Path
+) -> None:
+    output_dir = tmp_path / "grouped"
+    output_dir.mkdir()
+    input_dir = tmp_path / "input"
+    shutil.copytree(dicom_dir, input_dir)
+    (input_dir / "notes.txt").write_text("not a recognised format")
+
+    with pytest.raises(FormatRecognitionError, match="notes.txt"):
+        group(
+            input_paths=[str(input_dir)],
+            output_dir=output_dir,
+            datatypes=[DicomSeries],
+            session=SESSION_FIELD,
+            scan=SCAN_FIELD,
+            resource=RESOURCE_FIELD,
+            ignore=r"unrelated-pattern",
+        )
 
 
 def test_group_creates_build_dir(tmp_path: Path) -> None:

--- a/xnat_ingest/cli/group_cli.py
+++ b/xnat_ingest/cli/group_cli.py
@@ -10,7 +10,6 @@ from xnat_ingest.cli.base import cli
 
 from ..api.group_api import group, group_orthanc
 from ..helpers.arg_types import (
-    CliType,
     CollationSpec,
     CopyModeParamType,
     IDSpec,
@@ -119,8 +118,8 @@ are uploaded to XNAT
 @click.option(
     "--ignore-path",
     "ignore_paths",
-    type=CliType(str, multiple=True),
-    default=None,
+    type=str,
+    default=(),
     multiple=True,
     envvar="XINGEST_IGNORE_PATH",
     help=(

--- a/xnat_ingest/cli/group_cli.py
+++ b/xnat_ingest/cli/group_cli.py
@@ -10,6 +10,7 @@ from xnat_ingest.cli.base import cli
 
 from ..api.group_api import group, group_orthanc
 from ..helpers.arg_types import (
+    CliType,
     CollationSpec,
     CopyModeParamType,
     IDSpec,
@@ -116,14 +117,29 @@ are uploaded to XNAT
     ),
 )
 @click.option(
-    "--ignore",
-    type=str,
+    "--ignore-path",
+    "ignore_paths",
+    type=CliType(str, multiple=True),
     default=None,
-    envvar="XINGEST_IGNORE",
+    multiple=True,
+    envvar="XINGEST_IGNORE_PATH",
     help=(
-        "A regular expression to match paths that should be ignored when grouping files into sessions. "
-        "If None, no paths will be ignored. To ignore all paths by default, use '.*' as the value for this parameter. "
-        "(XINGEST_IGNORE env. var)"
+        "Regular expressions to match paths that should be ignored when grouping files into sessions. "
+        "If None, no paths will be ignored. To ignore all paths by default, use '.*' as the value "
+        "for this parameter. (XINGEST_IGNORE env. var)"
+    ),
+)
+@click.option(
+    "--ignore-type",
+    "ignore_types",
+    type=MimeType.cli_type,
+    default=None,
+    multiple=True,
+    envvar="XINGEST_IGNORE_TYPE",
+    help=(
+        "Datatypes that should be ignored when grouping files into sessions. If None, paths "
+        "that aren't recognised as part of the requested datatypes or filtered using "
+        "ignore_paths will raise an error (XINGEST_IGNORE env. var)"
     ),
 )
 @click.option(
@@ -229,7 +245,8 @@ def group_cmd(
     additional_loggers: ty.List[str],
     raise_errors: bool,
     avoid_clashes: bool,
-    ignore: str | None,
+    ignore_paths: list[str] | None,
+    ignore_types: list[MimeType] | None,
     loop: int,
     wait_period: int,
     recursive: bool,
@@ -261,7 +278,8 @@ def group_cmd(
             unlink_source=unlink_source,
             raise_errors=raise_errors,
             copy_mode=copy_mode,
-            ignore=ignore,
+            ignore_paths=ignore_paths,
+            ignore_types=[dt.datatype for dt in ignore_types],
             avoid_clashes=avoid_clashes,
             wait_period=wait_period,
             path_metadata_regex=path_metadata_regex,

--- a/xnat_ingest/cli/group_cli.py
+++ b/xnat_ingest/cli/group_cli.py
@@ -107,6 +107,26 @@ are uploaded to XNAT
     ),
 )
 @click.option(
+    "--avoid-clashes/--allow-clashes",
+    type=bool,
+    default=True,
+    help=(
+        "Whether to avoid clashes in resource names by appending _1, _2 etc. to the name until a "
+        "unique name is found (default: True)"
+    ),
+)
+@click.option(
+    "--ignore",
+    type=str,
+    default=None,
+    envvar="XINGEST_IGNORE",
+    help=(
+        "A regular expression to match paths that should be ignored when grouping files into sessions. "
+        "If None, no paths will be ignored. To ignore all paths by default, use '.*' as the value for this parameter. "
+        "(XINGEST_IGNORE env. var)"
+    ),
+)
+@click.option(
     "--loop",
     type=int,
     default=-1,
@@ -208,6 +228,8 @@ def group_cmd(
     loggers: ty.List[LoggerConfig],
     additional_loggers: ty.List[str],
     raise_errors: bool,
+    avoid_clashes: bool,
+    ignore: str | None,
     loop: int,
     wait_period: int,
     recursive: bool,
@@ -239,6 +261,8 @@ def group_cmd(
             unlink_source=unlink_source,
             raise_errors=raise_errors,
             copy_mode=copy_mode,
+            ignore=ignore,
+            avoid_clashes=avoid_clashes,
             wait_period=wait_period,
             path_metadata_regex=path_metadata_regex,
             recursive=recursive,

--- a/xnat_ingest/cli/tests/test_cli.py
+++ b/xnat_ingest/cli/tests/test_cli.py
@@ -812,7 +812,7 @@ def test_group_ignore_option_skips_unrecognised_files(
             "--raise-errors",
             "--wait-period",
             "0",
-            "--ignore",
+            "--ignore-path",
             r".*\.txt",
         ],
     )
@@ -868,7 +868,7 @@ def test_group_ignore_pattern_not_matching_still_fails(
             "--raise-errors",
             "--wait-period",
             "0",
-            "--ignore",
+            "--ignore-path",
             r"unrelated-pattern",
         ],
     )

--- a/xnat_ingest/cli/tests/test_cli.py
+++ b/xnat_ingest/cli/tests/test_cli.py
@@ -11,6 +11,7 @@ import click
 import pytest
 import xnat4tests  # type: ignore[import-untyped]
 from fileformats.core import extra_implementation, SampleFileGenerator
+from fileformats.core.exceptions import FormatRecognitionError
 from fileformats.application import Json
 from fileformats.medimage import DicomSeries
 from fileformats.testing import MyFormat, MyFormatGz
@@ -789,6 +790,90 @@ def test_group_path_metadata_regex(
     resource_dir = next(d for d in scan_dir.iterdir() if d.is_dir())
     mdata = json.loads((resource_dir / Metadata.FNAME).read_bytes())
     assert mdata["cohort"] == "cohort-A"
+
+
+def test_group_ignore_option_skips_unrecognised_files(
+    cli_runner: ty.Any,
+    tmp_path: Path,
+) -> None:
+    sorted_dir = tmp_path / "sorted"
+    sorted_dir.mkdir()
+
+    dicoms_dir = tmp_path / "dicoms"
+    dicoms_dir.mkdir()
+    get_pet_image(dicoms_dir)
+    (dicoms_dir / "notes.txt").write_text("not a recognised format")
+
+    result = cli_runner(
+        group_cmd,
+        [
+            str(dicoms_dir),
+            str(sorted_dir),
+            "--raise-errors",
+            "--wait-period",
+            "0",
+            "--ignore",
+            r".*\.txt",
+        ],
+    )
+    assert result.exit_code == 0, show_cli_trace(result)
+
+    session_dirs = list_session_dirs(sorted_dir)
+    assert len(session_dirs) == 1
+
+
+def test_group_without_ignore_fails_on_unrecognised_file(
+    cli_runner: ty.Any,
+    tmp_path: Path,
+) -> None:
+    sorted_dir = tmp_path / "sorted"
+    sorted_dir.mkdir()
+
+    dicoms_dir = tmp_path / "dicoms"
+    dicoms_dir.mkdir()
+    get_pet_image(dicoms_dir)
+    (dicoms_dir / "notes.txt").write_text("not a recognised format")
+
+    result = cli_runner(
+        group_cmd,
+        [
+            str(dicoms_dir),
+            str(sorted_dir),
+            "--raise-errors",
+            "--wait-period",
+            "0",
+        ],
+    )
+    assert result.exit_code != 0
+    assert isinstance(result.exception, FormatRecognitionError)
+
+
+def test_group_ignore_pattern_not_matching_still_fails(
+    cli_runner: ty.Any,
+    tmp_path: Path,
+) -> None:
+    sorted_dir = tmp_path / "sorted"
+    sorted_dir.mkdir()
+
+    dicoms_dir = tmp_path / "dicoms"
+    dicoms_dir.mkdir()
+    get_pet_image(dicoms_dir)
+    (dicoms_dir / "notes.txt").write_text("not a recognised format")
+
+    result = cli_runner(
+        group_cmd,
+        [
+            str(dicoms_dir),
+            str(sorted_dir),
+            "--raise-errors",
+            "--wait-period",
+            "0",
+            "--ignore",
+            r"unrelated-pattern",
+        ],
+    )
+    assert result.exit_code != 0
+    assert isinstance(result.exception, FormatRecognitionError)
 
 
 def test_sort_orthanc_collate_resources(

--- a/xnat_ingest/cli/tests/test_cli.py
+++ b/xnat_ingest/cli/tests/test_cli.py
@@ -792,7 +792,7 @@ def test_group_path_metadata_regex(
     assert mdata["cohort"] == "cohort-A"
 
 
-def test_group_ignore_option_skips_unrecognised_files(
+def test_group_ignore_path_option_skips_unrecognised_files(
     cli_runner: ty.Any,
     tmp_path: Path,
 ) -> None:
@@ -822,7 +822,7 @@ def test_group_ignore_option_skips_unrecognised_files(
     assert len(session_dirs) == 1
 
 
-def test_group_without_ignore_fails_on_unrecognised_file(
+def test_group_without_ignore_path_fails_on_unrecognised_file(
     cli_runner: ty.Any,
     tmp_path: Path,
 ) -> None:
@@ -848,7 +848,7 @@ def test_group_without_ignore_fails_on_unrecognised_file(
     assert isinstance(result.exception, FormatRecognitionError)
 
 
-def test_group_ignore_pattern_not_matching_still_fails(
+def test_group_ignore_path_pattern_not_matching_still_fails(
     cli_runner: ty.Any,
     tmp_path: Path,
 ) -> None:
@@ -874,6 +874,91 @@ def test_group_ignore_pattern_not_matching_still_fails(
     )
     assert result.exit_code != 0
     assert isinstance(result.exception, FormatRecognitionError)
+
+
+def test_group_ignore_type_excludes_recognised_but_unwanted_files(
+    cli_runner: ty.Any,
+    tmp_path: Path,
+) -> None:
+    sorted_dir = tmp_path / "sorted"
+    sorted_dir.mkdir()
+
+    dicoms_dir = tmp_path / "dicoms"
+    dicoms_dir.mkdir()
+    get_pet_image(dicoms_dir)
+    (dicoms_dir / "notes.json").write_text("{}")
+
+    result = cli_runner(
+        group_cmd,
+        [
+            str(dicoms_dir),
+            str(sorted_dir),
+            "--raise-errors",
+            "--wait-period",
+            "0",
+            "--ignore-type",
+            "application/json",
+        ],
+    )
+    assert result.exit_code == 0, show_cli_trace(result)
+
+    session_dirs = list_session_dirs(sorted_dir)
+    assert len(session_dirs) == 1
+
+
+def test_group_without_ignore_type_fails_on_recognised_extra_type(
+    cli_runner: ty.Any,
+    tmp_path: Path,
+) -> None:
+    sorted_dir = tmp_path / "sorted"
+    sorted_dir.mkdir()
+
+    dicoms_dir = tmp_path / "dicoms"
+    dicoms_dir.mkdir()
+    get_pet_image(dicoms_dir)
+    (dicoms_dir / "notes.json").write_text("{}")
+
+    result = cli_runner(
+        group_cmd,
+        [
+            str(dicoms_dir),
+            str(sorted_dir),
+            "--raise-errors",
+            "--wait-period",
+            "0",
+        ],
+    )
+    assert result.exit_code != 0
+    assert isinstance(result.exception, FormatRecognitionError)
+
+
+def test_group_ignore_type_contradicting_datatype_fails(
+    cli_runner: ty.Any,
+    tmp_path: Path,
+) -> None:
+    sorted_dir = tmp_path / "sorted"
+    sorted_dir.mkdir()
+
+    dicoms_dir = tmp_path / "dicoms"
+    dicoms_dir.mkdir()
+    get_pet_image(dicoms_dir)
+
+    result = cli_runner(
+        group_cmd,
+        [
+            str(dicoms_dir),
+            str(sorted_dir),
+            "--raise-errors",
+            "--wait-period",
+            "0",
+            "--datatype",
+            "medimage/dicom-series",
+            "--ignore-type",
+            "medimage/dicom-series",
+        ],
+    )
+    assert result.exit_code != 0
+    assert isinstance(result.exception, ValueError)
 
 
 def test_sort_orthanc_collate_resources(

--- a/xnat_ingest/model/session.py
+++ b/xnat_ingest/model/session.py
@@ -18,6 +18,7 @@ import yaml
 from filelock import SoftFileLock
 from tqdm import tqdm
 from fileformats.core import FileSet, from_mime, from_paths, to_mime
+from fileformats.generic import Directory
 from fileformats.core.utils import collate_metadata_series
 from fileformats.application import Yaml
 from fileformats.medimage import DicomCollection
@@ -301,7 +302,8 @@ class ImagingSession:
         resource_field: list[IDSpec],
         recursive: bool = False,
         avoid_clashes: bool = True,
-        ignore: str | None = None,
+        ignore_paths: list[str] | None = None,
+        ignore_types: list[type[FileSet]] | None = None,
         path_metadata_regex: ty.Sequence[PathMetadataRegex] = (),
     ) -> ty.List[Self]:
         """Loads all imaging sessions from a list of DICOM files
@@ -328,8 +330,10 @@ class ImagingSession:
             if a resource with the same name already exists in the scan, increment the
             resource name by appending _1, _2 etc. to the name until a unique name is found,
             by default False
-        ignore : str or None, optional
-            a regular expression to match paths that should be ignored
+        ignore_paths : list[str] or None, optional
+            regular expressions to match paths that should be ignored
+        ignore_types : list[type[FileSet]] or None, optional
+            types to be ignored
         path_metadata_regex : ty.Sequence[PathMetadataRegex], optional
             Regular expressions to extract "metadata" values from resource file paths as named groups. The named
             groups are used as metadata fields for the resource files, and the extracted values will be used to populate
@@ -347,6 +351,24 @@ class ImagingSession:
             if values extracted from IDs across the DICOM scans are not consistent across
             DICOM files within the session
         """
+
+        if ignore_types:
+            if contradicting := set(datatypes) & set(ignore_types):
+                raise ValueError(
+                    "The following datatypes were listed for both inclusion (`datatypes`) and exclusion "
+                    f"(`ignore_types`): {list(contradicting)}"
+                )
+        else:
+            ignore_types = []
+
+        if recursive:
+            if Directory in datatypes or FileSet in datatypes:
+                raise ValueError(
+                    "Cannot use `generic/directory` or `generic/file-set` datatypes with the `recursive` option. Please "
+                    "define a more specific directory datatype (datatypes={datatypes})"
+                )
+            ignore_types.append(Directory)
+
         if isinstance(files_path, (Path, str)):
             files_path = [files_path]
         elif not isinstance(files_path, ty.Sequence):
@@ -413,10 +435,15 @@ class ImagingSession:
         logger.info(f"Loading {datatypes} from {files_path}...")
         filesets = from_paths(
             fspaths,
-            *datatypes,
-            ignore=ignore,
+            *(datatypes + ignore_types),
+            ignore="|".join(ignore_paths),
             **from_paths_kwargs,  # type: ignore[arg-type]
         )
+        if ignore_types:
+            filesets = [
+                f for f in filesets if not any(isinstance(f, t) for t in ignore_types)
+            ]
+
         sessions: ty.Dict[ty.Tuple[str, str, str] | str, Self] = {}
 
         for fileset in tqdm(

--- a/xnat_ingest/model/session.py
+++ b/xnat_ingest/model/session.py
@@ -301,6 +301,7 @@ class ImagingSession:
         resource_field: list[IDSpec],
         recursive: bool = False,
         avoid_clashes: bool = True,
+        ignore: str | None = None,
         path_metadata_regex: ty.Sequence[PathMetadataRegex] = (),
     ) -> ty.List[Self]:
         """Loads all imaging sessions from a list of DICOM files
@@ -319,7 +320,7 @@ class ImagingSession:
         scan_field: list[IdField]
             the value of this field is used to group resources under single scans.
         resource_field: list[IdField]
-            the value of this field is to resources
+            the value of this field is used to identify resources
         recursive : bool, optional
             recurse into directories passed as file paths (i.e. by appending ``**/*`` and running a glob),
             by default False
@@ -327,6 +328,8 @@ class ImagingSession:
             if a resource with the same name already exists in the scan, increment the
             resource name by appending _1, _2 etc. to the name until a unique name is found,
             by default False
+        ignore : str or None, optional
+            a regular expression to match paths that should be ignored
         path_metadata_regex : ty.Sequence[PathMetadataRegex], optional
             Regular expressions to extract "metadata" values from resource file paths as named groups. The named
             groups are used as metadata fields for the resource files, and the extracted values will be used to populate
@@ -411,7 +414,7 @@ class ImagingSession:
         filesets = from_paths(
             fspaths,
             *datatypes,
-            ignore=".*",
+            ignore=ignore,
             **from_paths_kwargs,  # type: ignore[arg-type]
         )
         sessions: ty.Dict[ty.Tuple[str, str, str] | str, Self] = {}

--- a/xnat_ingest/model/session.py
+++ b/xnat_ingest/model/session.py
@@ -436,7 +436,7 @@ class ImagingSession:
         filesets = from_paths(
             fspaths,
             *(datatypes + ignore_types),
-            ignore="|".join(ignore_paths),
+            ignore="|".join(ignore_paths) if ignore_paths else None,
             **from_paths_kwargs,  # type: ignore[arg-type]
         )
         if ignore_types:


### PR DESCRIPTION
This is a breaking change because if an unrecognised file isn't explicitly ignored with the `--ignore` option `group` will now raise an error instead of silently dropping the file from the upload.