### PR TITLE
 Implement multi-threading across project on I/O heavy opterations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,10 @@ repos:
           - id: end-of-file-fixer
           - id: check-yaml
           - id: check-added-large-files
+    - repo: https://github.com/PyCQA/isort
+      rev: 5.13.2
+      hooks:
+          - id: isort
     - repo: https://github.com/psf/black
       rev: 22.3.0
       hooks:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,10 +12,11 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 from __future__ import print_function
+
+import datetime
+import re
 import typing as ty
 from pathlib import Path
-import re
-import datetime
 
 try:
     import tomllib

--- a/real-tests/usyd_stage.py
+++ b/real-tests/usyd_stage.py
@@ -1,9 +1,9 @@
 import logging
 
 from click.testing import CliRunner
-from xnat_ingest.utils import show_cli_trace
 
 from xnat_ingest.cli import sort
+from xnat_ingest.utils import show_cli_trace
 
 runner = CliRunner()
 

--- a/real-tests/usyd_transfer.py
+++ b/real-tests/usyd_transfer.py
@@ -1,4 +1,5 @@
 from click.testing import CliRunner
+
 from xnat_ingest.cli import transfer
 from xnat_ingest.utils import show_cli_trace
 

--- a/scripts/dcm_performance_mrtrix.py
+++ b/scripts/dcm_performance_mrtrix.py
@@ -1,6 +1,8 @@
 import timeit
+
 from fileformats.medimage import DicomSeries
 from medimages4tests.dummy.dicom.mri.dwi.siemens.skyra.syngo_d13c import get_image
+
 import xnat_ingest.dicom  # noqa
 
 METADATA_KEYS = [

--- a/scripts/dcm_performance_pydicom.py
+++ b/scripts/dcm_performance_pydicom.py
@@ -1,4 +1,5 @@
 import timeit
+
 from fileformats.medimage import DicomSeries
 from medimages4tests.dummy.dicom.mri.dwi.siemens.skyra.syngo_d13c import get_image
 

--- a/scripts/get_pet_tst.py
+++ b/scripts/get_pet_tst.py
@@ -1,10 +1,10 @@
 import tempfile
 from pathlib import Path
-from fileformats.medimage import DicomSeries
-from medimages4tests.dummy.dicom.pet.wholebody.siemens.biograph_vision.vr20b import (  # type: ignore[import-untyped]
-    get_image as get_pet_image,
-)
 
+from fileformats.medimage import DicomSeries
+from medimages4tests.dummy.dicom.pet.wholebody.siemens.biograph_vision.vr20b import (
+    get_image as get_pet_image,  # type: ignore[import-untyped]
+)
 
 tmp_path = Path(tempfile.mkdtemp())
 

--- a/scripts/logging_testing.py
+++ b/scripts/logging_testing.py
@@ -1,7 +1,7 @@
 from click.testing import CliRunner
-from xnat_ingest.utils import show_cli_trace
 
 from xnat_ingest.cli.sort import sort
+from xnat_ingest.utils import show_cli_trace
 
 runner = CliRunner()
 result = runner.invoke(

--- a/xnat_ingest/api/__init__.py
+++ b/xnat_ingest/api/__init__.py
@@ -1,9 +1,9 @@
+from .assign_api import INVALID_DIRNAME, assign
 from .associate_api import associate
-from .assign_api import assign, INVALID_DIRNAME
 from .check_upload_api import check_upload
-from .group_api import group, group_orthanc, BUILD_NAME_DEFAULT
-from .upload_api import upload
 from .deidentify_api import deidentify
+from .group_api import BUILD_NAME_DEFAULT, group, group_orthanc
+from .upload_api import upload
 
 __all__ = [
     "upload",

--- a/xnat_ingest/api/check_upload_api.py
+++ b/xnat_ingest/api/check_upload_api.py
@@ -3,13 +3,14 @@ import pprint
 import subprocess as sp
 import tempfile
 import typing as ty
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
-from tqdm import tqdm
 import xnat
 from fileformats.core import FileSet, from_mime, to_mime
 from fileformats.medimage import DicomSeries
 from frametree.xnat import Xnat
+from tqdm import tqdm
 from xnat.exceptions import XNATResponseError
 
 from xnat_ingest.helpers.arg_types import StoreCredentials
@@ -33,6 +34,7 @@ def check_upload(
     verify_ssl: bool = True,
     use_curl_jsession: bool = False,
     disable_progress: bool = False,
+    max_workers: ty.Optional[int] = None,
 ) -> None:
     """Checks the staged sessions against the XNAT server to check for any issues before upload.
 
@@ -58,6 +60,10 @@ def check_upload(
         A list of MIME types to always include in the check, even if they aren't defined in
         the frameset on XNAT. This can be used to include additional file formats that aren't
         defined in the frameset, or to include all file formats by using "all".
+    max_workers : int, optional
+        the number of threads to use to fetch checksums from XNAT concurrently
+        (per-session), once the resources to check have been resolved. If None,
+        defaults to `concurrent.futures.ThreadPoolExecutor`'s default.
     """
 
     xnat_repo = Xnat(
@@ -171,6 +177,12 @@ def check_upload(
 
             logger.info("CHECKING %s", session_listing.name)
 
+            # Resolve which resources need a checksum comparison sequentially, since
+            # this touches xnatpy's lazy-loading scan/resource caches (of uncertain
+            # thread-safety) and can trigger a catalog-refresh POST. The checksum
+            # fetch itself (get_xnat_checksums) is a stateless GET against an
+            # already-resolved resource, so it's safe to fan out below.
+            to_check: list[tuple[str, str, str, ty.Dict[str, str], ty.Any]] = []
             for resource_path, manifests in session_listing.resource_manifests.items():
                 scan_path, resource_name = resource_path.split("/", 1)
                 scan_id, _ = scan_path.split(".", 1)
@@ -243,7 +255,22 @@ def check_upload(
                     )
                     num_issues += 1
                     continue
-                xchecksums = get_xnat_checksums(xresource)
+                to_check.append(
+                    (scan_path, resource_name, session_desc, checksums, xresource)
+                )
+
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                all_xchecksums = executor.map(
+                    lambda item: get_xnat_checksums(item[4]), to_check
+                )
+
+            for (
+                scan_path,
+                resource_name,
+                session_desc,
+                checksums,
+                _,
+            ), xchecksums in zip(to_check, all_xchecksums):
                 if not any(xchecksums.values()):
                     logger.debug(
                         "Skipping checksum check for '%s' resource in '%s' in %s as "

--- a/xnat_ingest/api/deidentify_api.py
+++ b/xnat_ingest/api/deidentify_api.py
@@ -1,14 +1,13 @@
-import os
 import json
+import os
 import traceback
-from pathlib import Path
 import typing as ty
+from pathlib import Path
 
 from cryptography.fernet import Fernet
-from fileformats.core import extra_implementation, from_mime
+from fileformats.core import FileSet, extra_implementation, from_mime
 from fileformats.medimage.base import MedicalImagingData
 from fileformats.medimage.dicom import DicomImage
-from fileformats.core import FileSet
 from tqdm import tqdm
 
 from xnat_ingest.helpers.remotes import LocalSessionListing, list_session_dirs

--- a/xnat_ingest/api/group_api.py
+++ b/xnat_ingest/api/group_api.py
@@ -24,7 +24,7 @@ def group(
     unlink_source: str | None = None,
     raise_errors: bool = False,
     copy_mode: FileSet.CopyMode = FileSet.CopyMode.hardlink_or_copy,
-    collation_map: dict[ty.Type[FileSet], FileSet.CopyCollation] | None = None,
+    collation_map: dict[type[FileSet], FileSet.CopyCollation] | None = None,
     ignore_paths: list[str] | None = None,
     ignore_types: list[type[FileSet]] = (),
     wait_period: int = 0,
@@ -109,7 +109,7 @@ def group(
 
     errors = save_sessions_to_dir(
         sessions,
-        f"Grouping files found in '{input_paths}' to {str(output_dir)}",
+        f"Grouping files found in '{input_paths}' to {output_dir!s}",
         wait_period=wait_period,
         build_dir=build_dir,
         copy_mode=copy_mode,

--- a/xnat_ingest/api/tests/test_assign.py
+++ b/xnat_ingest/api/tests/test_assign.py
@@ -5,8 +5,8 @@ import pytest
 from fileformats.core import FileSet
 from fileformats.medimage import DicomSeries
 from medimages4tests.dummy.dicom.pet.wholebody.siemens.biograph_vision.vr20b import (
-    get_image as get_pet_image,
-)  # type: ignore[import-untyped]
+    get_image as get_pet_image,  # type: ignore[import-untyped]
+)
 
 from xnat_ingest.api.assign_api import INVALID_DIRNAME, assign
 from xnat_ingest.api.group_api import group

--- a/xnat_ingest/api/tests/test_group.py
+++ b/xnat_ingest/api/tests/test_group.py
@@ -6,13 +6,10 @@ from fileformats.application import Json
 from fileformats.core.exceptions import FormatRecognitionError
 from fileformats.medimage import DicomSeries
 from medimages4tests.dummy.dicom.pet.wholebody.siemens.biograph_vision.vr20b import (
-    get_image as get_pet_image,
-)  # type: ignore[import-untyped]
-
-from xnat_ingest.api.group_api import (
-    BUILD_NAME_DEFAULT,
-    group,
+    get_image as get_pet_image,  # type: ignore[import-untyped]
 )
+
+from xnat_ingest.api.group_api import BUILD_NAME_DEFAULT, group
 from xnat_ingest.helpers.arg_types import IDSpec
 from xnat_ingest.model.session import ImagingSession
 

--- a/xnat_ingest/api/upload_api.py
+++ b/xnat_ingest/api/upload_api.py
@@ -3,6 +3,7 @@ import shutil
 import tempfile
 import traceback
 import typing as ty
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 from fileformats.generic import File, FileSet
@@ -43,6 +44,7 @@ def upload(
     s3_cache_dir: ty.Optional[Path] = None,
     raise_errors: bool = False,
     dry_run: bool = False,
+    max_workers: ty.Optional[int] = None,
 ) -> list[str]:
     """Upload sorted sessions in the given staging directory to XNAT
 
@@ -74,6 +76,12 @@ def upload(
         the checksums of the files in the staged resources (if available) to verify that they were
     dry_run: bool
          Whether to list the sessions that would be uploaded instead of actually uploading them
+    max_workers: int, optional
+        The number of threads to use to upload resources within a session concurrently.
+        Different resources map to different scans/catalogs on XNAT so are safe to
+        upload in parallel; a failure uploading one resource doesn't stop the others
+        from being attempted. If None, defaults to
+        `concurrent.futures.ThreadPoolExecutor`'s default.
     """
 
     errors = []
@@ -219,13 +227,14 @@ def upload(
                         f"{session.path} regardless of whether they are explicitly specified"
                     )
 
-                for resource in tqdm(
-                    sorted(
-                        session.select_resources(
-                            frameset, always_include=always_include
-                        )
-                    ),
-                    f"Uploading resources found in {session.name}",
+                # Resolve which resources need uploading sequentially -- this can
+                # create new scans/resources on XNAT and mutates xsession's/xscan's
+                # shared caches, so isn't safe to do concurrently. The actual upload
+                # of each resource's files is independent (different resources map to
+                # different scan/resource catalogs on XNAT) so is safe to fan out.
+                to_upload: list[tuple[ImagingResource, ty.Any]] = []
+                for resource in sorted(
+                    session.select_resources(frameset, always_include=always_include)
                 ):
                     xresource = get_xnat_resource(resource, xsession)
                     if xresource is None:
@@ -234,12 +243,16 @@ def upload(
                             resource.path,
                         )
                         continue  # skipping as resource already exists
-                    else:
-                        logger.debug(
-                            "Uploading '%s' resource to '%s'",
-                            resource.path,
-                            xresource,
-                        )
+                    to_upload.append((resource, xresource))
+
+                def _upload_resource(
+                    resource: ImagingResource, xresource: ty.Any
+                ) -> None:
+                    logger.debug(
+                        "Uploading '%s' resource to '%s'",
+                        resource.path,
+                        xresource,
+                    )
                     if isinstance(resource.fileset, File):
                         for fspath in resource.fileset.fspaths:
                             logger.debug(
@@ -343,7 +356,43 @@ def upload(
                         )
 
                     logger.info(f"Uploaded '{resource.path}' in '{session.name}'")
-                logger.info(f"Successfully uploaded all files in '{session.name}'")
+
+                resource_errors: list[tuple[ImagingResource, BaseException]] = []
+                with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                    futures = {
+                        executor.submit(_upload_resource, resource, xresource): resource
+                        for resource, xresource in to_upload
+                    }
+                    for future in tqdm(
+                        as_completed(futures),
+                        total=len(futures),
+                        desc=f"Uploading resources found in {session.name}",
+                    ):
+                        resource = futures[future]
+                        try:
+                            future.result()
+                        except Exception as e:
+                            logger.error(
+                                "Failed to upload '%s' resource in '%s': %s\n%s",
+                                resource.path,
+                                session.name,
+                                e,
+                                traceback.format_exc(),
+                            )
+                            resource_errors.append((resource, e))
+
+                if resource_errors:
+                    msg = (
+                        f"{len(resource_errors)} of {len(to_upload)} resource(s) "
+                        f"failed to upload in '{session.name}': "
+                        + ", ".join(r.path for r, _ in resource_errors)
+                    )
+                    errors.append(msg)
+                    if raise_errors:
+                        raise RuntimeError(msg) from resource_errors[0][1]
+                    logger.error(msg)
+                else:
+                    logger.info(f"Successfully uploaded all files in '{session.name}'")
                 # Extract DICOM metadata
                 logger.info("Extracting metadata from DICOMs on XNAT..")
                 try:
@@ -377,8 +426,10 @@ def upload(
             except Exception as e:
                 if not raise_errors:
                     msg = [
-                        f"Skipping upload of '{session_listing.name}' due to error: \"{e}\""
-                        f"\n{traceback.format_exc()}\n\n"
+                        (
+                            f"Skipping upload of '{session_listing.name}' due to error: \"{e}\""
+                            f"\n{traceback.format_exc()}\n\n"
+                        )
                     ]
                     logger.error("".join(msg))
                     errors.extend(msg)

--- a/xnat_ingest/cli/assign_cli.py
+++ b/xnat_ingest/cli/assign_cli.py
@@ -9,10 +9,7 @@ from fileformats.core import FileSet
 from xnat_ingest.cli.base import cli
 
 from ..api.assign_api import assign
-from ..helpers.arg_types import (
-    CopyModeParamType,
-    LoggerConfig,
-)
+from ..helpers.arg_types import CopyModeParamType, LoggerConfig
 from ..helpers.logging import logger, set_logger_handling
 
 

--- a/xnat_ingest/cli/associate_cli.py
+++ b/xnat_ingest/cli/associate_cli.py
@@ -8,9 +8,9 @@ import click
 from fileformats.core import FileSet
 
 from ..api import associate
-from .base import cli
 from ..helpers.arg_types import LoggerConfig
 from ..helpers.logging import logger, set_logger_handling
+from .base import cli
 
 PRE_STAGE_NAME_DEFAULT = "PRE-STAGE"
 STAGED_NAME_DEFAULT = "STAGED"

--- a/xnat_ingest/cli/tests/test_cli.py
+++ b/xnat_ingest/cli/tests/test_cli.py
@@ -10,26 +10,26 @@ from unittest.mock import patch
 import click
 import pytest
 import xnat4tests  # type: ignore[import-untyped]
-from fileformats.core import extra_implementation, SampleFileGenerator
-from fileformats.core.exceptions import FormatRecognitionError
 from fileformats.application import Json
+from fileformats.core import SampleFileGenerator, extra_implementation
+from fileformats.core.exceptions import FormatRecognitionError
 from fileformats.medimage import DicomSeries
 from fileformats.testing import MyFormat, MyFormatGz
 from frametree.core.cli import add_source as dataset_add_source
 from frametree.core.cli import define as dataset_define  # type: ignore[import-untyped]
 from frametree.core.cli.store import add as store_add  # type: ignore[import-untyped]
 from medimages4tests.dummy.dicom.ct.ac.siemens.biograph_vision.vr20b import (
-    get_image as get_ac_image,
-)  # type: ignore[import-untyped]
+    get_image as get_ac_image,  # type: ignore[import-untyped]
+)
 from medimages4tests.dummy.dicom.pet.statistics.siemens.biograph_vision.vr20b import (
-    get_image as get_statistics_image,
-)  # type: ignore[import-untyped]
+    get_image as get_statistics_image,  # type: ignore[import-untyped]
+)
 from medimages4tests.dummy.dicom.pet.topogram.siemens.biograph_vision.vr20b import (
-    get_image as get_topogram_image,
-)  # type: ignore[import-untyped]
+    get_image as get_topogram_image,  # type: ignore[import-untyped]
+)
 from medimages4tests.dummy.dicom.pet.wholebody.siemens.biograph_vision.vr20b import (
-    get_image as get_pet_image,
-)  # type: ignore[import-untyped]
+    get_image as get_pet_image,  # type: ignore[import-untyped]
+)
 from moto import mock_aws
 
 from conftest import get_raw_data_files, show_cli_trace
@@ -1744,8 +1744,10 @@ def test_deidentify_cli_dicom_encrypted_reid(
     ImagingSession.deidentify is mocked so the test focuses on the encryption
     logic rather than the deidentification implementation.
     """
-    from cryptography.fernet import Fernet
     from unittest.mock import MagicMock
+
+    from cryptography.fernet import Fernet
+
     from xnat_ingest.model.session import ImagingSession
 
     PROJECT_ID = "TESTDEIDENCPROJECT"

--- a/xnat_ingest/cli/upload_cli.py
+++ b/xnat_ingest/cli/upload_cli.py
@@ -11,7 +11,6 @@ import click
 import requests.exceptions
 import xnat
 from frametree.xnat import Xnat
-
 from xnat.exceptions import XNATResponseError
 
 from xnat_ingest.cli.base import cli

--- a/xnat_ingest/helpers/logging.py
+++ b/xnat_ingest/helpers/logging.py
@@ -1,7 +1,6 @@
 """Helper functions and classes for logging"""
 
 import json
-
 import logging
 import os
 import sys

--- a/xnat_ingest/helpers/metadata.py
+++ b/xnat_ingest/helpers/metadata.py
@@ -1,8 +1,7 @@
-from itertools import chain
 import json
-from pathlib import Path
 import typing as ty
-
+from itertools import chain
+from pathlib import Path
 
 import attrs
 

--- a/xnat_ingest/helpers/remotes.py
+++ b/xnat_ingest/helpers/remotes.py
@@ -9,6 +9,7 @@ import shutil
 import tempfile
 import typing as ty
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import attrs
@@ -21,9 +22,9 @@ from tqdm import tqdm
 
 from ..model.resource import ImagingResource
 from ..model.session import ImagingSession
-from .metadata import Metadata
 from .arg_types import StoreCredentials
 from .logging import logger
+from .metadata import Metadata
 
 
 class SessionListing(metaclass=abc.ABCMeta):
@@ -194,19 +195,28 @@ class S3SessionListing(SessionListing):
     bucket: ty.Any
     objects: ty.List[ty.Tuple[ty.List[str], ty.Any]]
     _cache_path: Path
+    max_workers: ty.Optional[int] = None
 
     @property
     def cache_path(self) -> Path:
         logger.info("Downloading session '%s' from S3 bucket", self.name)
-        for relpath, obj in tqdm(
-            self.objects,
-            desc=f"Downloading scans in '{self.name}' session from S3 bucket",
-        ):
+
+        def _download(item: ty.Tuple[ty.List[str], ty.Any]) -> None:
+            relpath, obj = item
             obj_path = self._cache_path.joinpath(*relpath)
             obj_path.parent.mkdir(parents=True, exist_ok=True)
             logger.debug("Downloading %s to %s", obj, obj_path)
             with open(obj_path, "wb") as f:
                 self.bucket.download_fileobj(obj.key, f)
+
+        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+            list(
+                tqdm(
+                    executor.map(_download, self.objects),
+                    total=len(self.objects),
+                    desc=f"Downloading scans in '{self.name}' session from S3 bucket",
+                )
+            )
         return self._cache_path
 
     @property
@@ -594,7 +604,9 @@ def get_xnat_checksums(xresource: ty.Any) -> dict[str, str]:
     return dict((r["Name"], r["digest"]) for r in result.json()["ResultSet"]["Result"])
 
 
-def calculate_checksums(scan: FileSet) -> ty.Dict[str, str]:
+def calculate_checksums(
+    scan: FileSet, max_workers: ty.Optional[int] = None
+) -> ty.Dict[str, str]:
     """
     Calculates the MD5 digests associated with the files in a fileset.
 
@@ -602,14 +614,17 @@ def calculate_checksums(scan: FileSet) -> ty.Dict[str, str]:
     ----------
     scan : FileSet
         the file-set to calculate the checksums for
+    max_workers : int, optional
+        the number of threads to use to hash the files concurrently. If None,
+        defaults to `concurrent.futures.ThreadPoolExecutor`'s default.
 
     Returns
     -------
     dict[str, str]
         the calculated checksums
     """
-    checksums = {}
-    for fspath in scan.fspaths:
+
+    def _hash(fspath: Path) -> ty.Tuple[str, str]:
         try:
             hsh = hashlib.md5()
             with open(fspath, "rb") as f:
@@ -618,8 +633,10 @@ def calculate_checksums(scan: FileSet) -> ty.Dict[str, str]:
             checksum = hsh.hexdigest()
         except OSError:
             raise RuntimeError(f"Could not create digest of '{fspath}' ")
-        checksums[str(fspath.relative_to(scan.parent))] = checksum
-    return checksums
+        return str(fspath.relative_to(scan.parent)), checksum
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        return dict(executor.map(_hash, scan.fspaths))
 
 
 HASH_CHUNK_SIZE = 2**20

--- a/xnat_ingest/helpers/tests/test_dicom.py
+++ b/xnat_ingest/helpers/tests/test_dicom.py
@@ -1,8 +1,8 @@
 import pytest
 from fileformats.medimage import DicomSeries
 from medimages4tests.dummy.dicom.pet.wholebody.siemens.biograph_vision.vr20b import (
-    get_image as get_pet_image,
-)  # type: ignore[import-untyped]
+    get_image as get_pet_image,  # type: ignore[import-untyped]
+)
 
 # PATIENT_ID = "patient-id"
 # STUDY_ID = "study-id"

--- a/xnat_ingest/model/session.py
+++ b/xnat_ingest/model/session.py
@@ -5,26 +5,27 @@ import logging
 import os
 import platform
 import re
-import requests
 import typing as ty
 from collections import Counter
-from datetime import datetime
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime
 from functools import cached_property
 from glob import glob
 from pathlib import Path
+from typing import Self
 
 import attrs
+import requests
 import yaml
-from filelock import SoftFileLock
-from tqdm import tqdm
-from fileformats.core import FileSet, from_mime, from_paths, to_mime
-from fileformats.generic import Directory
-from fileformats.core.utils import collate_metadata_series
 from fileformats.application import Yaml
+from fileformats.core import FileSet, from_mime, from_paths, to_mime
+from fileformats.core.utils import collate_metadata_series
+from fileformats.generic import Directory
 from fileformats.medimage import DicomCollection
+from filelock import SoftFileLock
 from frametree.core.exceptions import FrameTreeDataMatchError
 from frametree.core.frameset import FrameSet
-from typing_extensions import Self
+from tqdm import tqdm
 
 from ..exceptions import ImagingSessionParseError, StagingError
 from ..helpers.arg_types import AssociatedFiles, IDSpec, PathMetadataRegex
@@ -174,7 +175,7 @@ class ImagingSession:
         return tuple(modalities)
 
     @property
-    def primary_parents(self) -> ty.Set[Path]:
+    def primary_parents(self) -> set[Path]:
         "Return parent directories for all resources in the session"
         return set(r.fileset.parent for r in self.primary_resources)
 
@@ -208,7 +209,7 @@ class ImagingSession:
 
     def select_resources(
         self,
-        dataset: ty.Optional[FrameSet],
+        dataset: FrameSet | None,
         always_include: ty.Sequence[str | FileSet] = (),
     ) -> ty.Iterator[ImagingResource]:
         """Returns selected resources that match the columns in the dataset definition
@@ -296,7 +297,7 @@ class ImagingSession:
     def from_paths(
         cls,
         files_path: str | Path | ty.Sequence[str | Path],
-        datatypes: ty.Union[ty.Type[FileSet], ty.Sequence[ty.Type[FileSet]]],
+        datatypes: type[FileSet] | ty.Sequence[type[FileSet]],
         session_field: list[IDSpec],
         scan_field: list[IDSpec],
         resource_field: list[IDSpec],
@@ -305,7 +306,7 @@ class ImagingSession:
         ignore_paths: list[str] | None = None,
         ignore_types: list[type[FileSet]] | None = None,
         path_metadata_regex: ty.Sequence[PathMetadataRegex] = (),
-    ) -> ty.List[Self]:
+    ) -> list[Self]:
         """Loads all imaging sessions from a list of DICOM files
 
         Parameters
@@ -316,12 +317,12 @@ class ImagingSession:
         datatypes : type or list[type]
             the fileformats to load from the paths, e.g. DicomSeries or
             [DicomSeries, NiftiGz]
-        session_field: list[IdField]
+        session_field: list[IDSpec]
             the metadata field that uniquely identifies the session, used to group files
             together before project/subject/visit IDs are extracted (e.g. StudyInstanceUID)
-        scan_field: list[IdField]
+        scan_field: list[IDSpec]
             the value of this field is used to group resources under single scans.
-        resource_field: list[IdField]
+        resource_field: list[IDSpec]
             the value of this field is used to identify resources
         recursive : bool, optional
             recurse into directories passed as file paths (i.e. by appending ``**/*`` and running a glob),
@@ -422,7 +423,7 @@ class ImagingSession:
         for fspath in fspaths:
             crypto.update(str(fspath.absolute()).encode())
         run_uid: str = crypto.hexdigest()[:6] + datetime.strftime(
-            datetime.now(),
+            datetime.now(UTC),
             "%Y%m%d%H%M%S",
         )
 
@@ -444,7 +445,7 @@ class ImagingSession:
                 f for f in filesets if not any(isinstance(f, t) for t in ignore_types)
             ]
 
-        sessions: ty.Dict[ty.Tuple[str, str, str] | str, Self] = {}
+        sessions: dict[tuple[str, str, str] | str, Self] = {}
 
         for fileset in tqdm(
             filesets,
@@ -576,7 +577,8 @@ class ImagingSession:
         password: str,
         to_process_label: str | None = None,
         processed_label: str = "xnat-sorted",
-    ) -> ty.List["ImagingSession"]:
+        max_workers: int | None = None,
+    ) -> list["ImagingSession"]:
         """Stage DICOM studies from Orthanc directly into output_dir using hardlinks.
         Requires orthanc_storage_dir and output_dir to be on the same filesystem.
 
@@ -596,6 +598,10 @@ class ImagingSession:
         processed_label : str, optional
             Label applied after staging to prevent re-processing, by default 'xnat-sorted'.
             Remove via the Orthanc UI to re-sort a study.
+        max_workers : int, optional
+            the number of threads to use to fetch per-instance attachment info from
+            Orthanc concurrently. If None, defaults to
+            `concurrent.futures.ThreadPoolExecutor`'s default.
 
         Returns
         -------
@@ -677,8 +683,12 @@ class ImagingSession:
                 resource_dir.mkdir(parents=True, exist_ok=True)
 
                 instances = get_json(f"/series/{series_id}/instances")
-                checksums: dict[str, str] = {}
-                for instance in instances:
+
+                def _link_instance(
+                    instance: ty.Mapping[str, ty.Any],
+                    resource_dir: Path = resource_dir,
+                    series_id: str = series_id,
+                ) -> tuple[str, str] | None:
                     instance_id = instance["ID"]
                     sop_uid = instance["MainDicomTags"].get(
                         "SOPInstanceUID", instance_id
@@ -686,7 +696,7 @@ class ImagingSession:
                     fname = f"{sop_uid}.dcm"
                     dest_path = resource_dir / fname
                     if dest_path.exists():
-                        continue
+                        return None
                     attachment = get_json(
                         f"/instances/{instance_id}/attachments/dicom/info"
                     )
@@ -699,7 +709,11 @@ class ImagingSession:
                     uuid = attachment["Uuid"]
                     src_path = Path(store_dir) / uuid[0:2] / uuid[2:4] / uuid
                     os.link(src_path, dest_path)
-                    checksums[fname] = attachment["UncompressedMD5"]
+                    return fname, attachment["UncompressedMD5"]
+
+                with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                    linked = executor.map(_link_instance, instances)
+                checksums: dict[str, str] = dict(r for r in linked if r is not None)
 
                 manifest = {"datatype": "medimage/dicom-series", "checksums": checksums}
                 with open(resource_dir / ImagingResource.MANIFEST_FNAME, "w") as f:
@@ -732,7 +746,7 @@ class ImagingSession:
     def deidentify(
         self,
         dest_dir: Path,
-        specs: dict[type[FileSet], ty.Any] = None,
+        specs: dict[type[FileSet], ty.Any] | None = None,
         copy_mode: FileSet.CopyMode = FileSet.CopyMode.hardlink_or_copy,
         avoid_clashes: bool = False,
         require_matching_spec: bool = True,
@@ -837,7 +851,7 @@ class ImagingSession:
 
     def associate_files(
         self,
-        patterns: ty.List[AssociatedFiles],
+        patterns: list[AssociatedFiles],
         spaces_to_underscores: bool = True,
         avoid_clashes: bool = False,
     ) -> list[FileSet]:
@@ -856,7 +870,7 @@ class ImagingSession:
             # substitute string templates int the glob template with values from the
             # DICOM metadata to construct a glob pattern to select files associated
             # with current session
-            associated_fspaths: ty.Set[Path] = set()
+            associated_fspaths: set[Path] = set()
             primary_parents = self.primary_parents
             if primary_parents:
                 for parent_dir in primary_parents:
@@ -919,7 +933,7 @@ class ImagingSession:
         overwrite: bool = False,
         associated: AssociatedFiles | None = None,
         avoid_clashes: bool = False,
-        metadata: ty.Mapping[str, ty.Any] = None,
+        metadata: dict[str, ty.Any] | None = None,
     ) -> None:
         """Adds a resource to the imaging session
 
@@ -1167,9 +1181,9 @@ class ImagingSession:
     def save(
         self,
         dest_dir: Path,
-        available_projects: ty.Optional[ty.List[str]] = None,
+        available_projects: list[str] | None = None,
         copy_mode: FileSet.CopyMode = FileSet.CopyMode.hardlink_or_copy,
-        collation_map: dict[ty.Type[FileSet], FileSet.CopyCollation] | None = None,
+        collation_map: dict[type[FileSet], FileSet.CopyCollation] | None = None,
     ) -> tuple[Self, Path]:
         r"""Saves the session to a directory. The session will be saved to a directory
         with the project, subject and session IDs as subdirectories of this directory,
@@ -1206,7 +1220,7 @@ class ImagingSession:
                 project_id = self.project_id
             else:
                 project_id = "INVALID_UNRECOGNISED_" + self.project_id
-            session_dirname = ".".join((project_id, self.subject_id, self.session_id))
+            session_dirname = f"{project_id}.{self.subject_id}.{self.session_id}"
             if self.run_uid:
                 session_dirname += f".{self.run_uid}"
         session_dir = dest_dir / session_dirname


### PR DESCRIPTION
session.py from_orthanc — per-instance Orthanc attachment-info GETs now run concurrently via ThreadPoolExecutor (max_workers param added). Also fixed an unrelated pre-existing bug on the same line (datetime.now(datetime.timezone.utc) crashing because the file imports the datetime class, not the module).

remotes.py calculate_checksums — per-file MD5 hashing now concurrent. remotes.py S3SessionListing.cache_path — per-object S3 downloads now concurrent. check_upload_api.py — restructured into resolve (sequential, touches xnatpy's caching) → fetch checksums (concurrent, stateless GETs) → compare (sequential) phases.