### PR TITLE
reconstruct reid metadata from a metadata diff, not deidentify()'s re…

### DIFF
--- a/xnat_ingest/api/deidentify_api.py
+++ b/xnat_ingest/api/deidentify_api.py
@@ -29,7 +29,21 @@ def deidentify(
     require_manifest: bool = True,
     unlink_source: str | None = None,
     reid_encrypt_key: bytes | None = None,
+    resource_workers: int | None = None,
+    file_workers: int | None = None,
 ) -> list[str]:
+    """
+    Parameters
+    ----------
+    resource_workers : int, optional
+        the number of processes to use to deidentify/copy a session's resources
+        concurrently. If None, defaults to
+        `concurrent.futures.ProcessPoolExecutor`'s default.
+    file_workers : int, optional
+        the number of threads handed to a resource's own deidentify implementation to
+        parallelise work within that resource (e.g. the per-file loop for a DICOM
+        series). Ignored by formats that don't support it.
+    """
 
     sessions: list[LocalSessionListing] = [
         LocalSessionListing(d) for d in list_session_dirs(input_dir)
@@ -77,6 +91,8 @@ def deidentify(
                 copy_mode=copy_mode,
                 avoid_clashes=avoid_clashes,
                 specs=specs,
+                resource_workers=resource_workers,
+                file_workers=file_workers,
             )
             deidentified_session.save(output_dir / session_listing.name)
             reid_mdata_json = json.dumps(reid_mdata, indent=2).encode()

--- a/xnat_ingest/api/deidentify_api.py
+++ b/xnat_ingest/api/deidentify_api.py
@@ -164,7 +164,8 @@ def load_specs(spec_dir: Path) -> ty.Mapping[ty.Type[MedicalImagingData], Path] 
 @extra_implementation(MedicalImagingData.deidentify)
 def dicom_deidentify(
     dicom: DicomImage,
+    out_dir: os.PathLike[str],
     spec: ty.Any = None,
-    out_dir: os.PathLike[str] | None = None,
-) -> tuple[DicomImage, ty.Mapping[str, ty.Any]]:
+    **kwargs: ty.Any,
+) -> DicomImage:
     raise NotImplementedError

--- a/xnat_ingest/model/session.py
+++ b/xnat_ingest/model/session.py
@@ -7,7 +7,7 @@ import platform
 import re
 import typing as ty
 from collections import Counter
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime
 from functools import cached_property
 from glob import glob
@@ -76,6 +76,62 @@ def scans_converter(
             raise ValueError(f"Found duplicate scan IDs in list of scans: {duplicates}")
         scans = {s.id: s for s in scans}
     return scans
+
+
+def _metadata_diff(
+    orig: ty.Mapping[str, ty.Any], new: ty.Mapping[str, ty.Any]
+) -> dict[str, ty.Any]:
+    """Return the fields of `orig` that are missing from or differ in `new`, i.e. the
+    original values of any metadata fields that were stripped/modified. Used to
+    reconstruct the reid metadata that `FileSet.deidentify()` implementations no
+    longer report themselves (see `fileformats.medimage.MedicalImagingData.deidentify`
+    docstring).
+    """
+    diff: dict[str, ty.Any] = {}
+    for key, val in orig.items():
+        try:
+            new_val = new[key]
+        except KeyError:
+            diff[key] = val
+            continue
+        if isinstance(val, ty.Mapping) and isinstance(new_val, ty.Mapping):
+            nested = _metadata_diff(val, new_val)
+            if nested:
+                diff[key] = nested
+        elif val != new_val:
+            diff[key] = val
+    return diff
+
+
+def _deidentify_or_copy_resource(
+    fileset: FileSet,
+    resource_name: str,
+    resource_dest_dir: Path,
+    contains_phi: bool,
+    spec: ty.Any,
+    copy_mode: FileSet.CopyMode,
+    file_workers: int | None,
+) -> tuple[FileSet, ty.Optional[ty.Mapping[str, ty.Any]]]:
+    """Deidentifies (or, for filesets that don't contain PHI, just copies) a single
+    resource. Module-level (not a closure) so it can be submitted to a
+    ProcessPoolExecutor, whose workers need to import and pickle it directly.
+    """
+    if not contains_phi:
+        return (
+            fileset.copy(
+                resource_dest_dir,
+                mode=copy_mode,
+                new_stem=resource_name,
+                avoid_clashes=True,
+            ),
+            None,
+        )
+    orig_metadata = dict(fileset.metadata)
+    deid_resource = fileset.deidentify(
+        out_dir=resource_dest_dir, spec=spec, max_workers=file_workers
+    )
+    reid_mdata = _metadata_diff(orig_metadata, deid_resource.metadata)
+    return deid_resource, reid_mdata
 
 
 @attrs.define(slots=False)
@@ -750,6 +806,8 @@ class ImagingSession:
         copy_mode: FileSet.CopyMode = FileSet.CopyMode.hardlink_or_copy,
         avoid_clashes: bool = False,
         require_matching_spec: bool = True,
+        resource_workers: int | None = None,
+        file_workers: int | None = None,
     ) -> tuple[Self, dict[str, ty.Any]]:
         """Creates a new session with deidentified images
 
@@ -772,6 +830,20 @@ class ImagingSession:
             by default False
         require_matching_spec : bool, optional
             whether to require a matching specification for each fileset, by default True
+        resource_workers : int, optional
+            the number of processes to use to deidentify/copy the scans' resources in this
+            session concurrently. Different resources are independent (separate output
+            directories) so are safe to process in parallel. Uses processes rather than
+            threads so that CPU-heavy format-specific deidentify implementations still
+            get real parallelism. If None, defaults to
+            `concurrent.futures.ProcessPoolExecutor`'s default.
+        file_workers : int, optional
+            the number of threads to hand to a resource's own deidentify implementation
+            for parallelising work *within* that resource (e.g. the per-file loop for a
+            DICOM series). Passed through as `max_workers` to `FileSet.deidentify`; formats
+            that don't accept/use it just ignore it. Useful for the case of a single large
+            resource dominating a session, where `resource_workers` alone can't help
+            since there's only one such resource to distribute across processes.
 
         Returns
         -------
@@ -804,18 +876,23 @@ class ImagingSession:
 
         # Create a new session to save the deidentified files into
         deidentified = self.new_empty()
-        reid_series = []
+
+        # Resolve the destination dir and deidentification spec for each resource
+        # sequentially -- spec selection can raise/warn and needs to happen before
+        # dispatch, and is cheap (pure dict lookups), so there's nothing to gain by
+        # parallelising it. The actual deidentify/copy work below is independent per
+        # resource (separate output directories) so is safe to fan out.
+        tasks: list[
+            tuple[str, str, str, FileSet, Path, bool, ty.Any]
+        ] = (
+            []
+        )  # (scan_id, scan_type, resource_name, fileset, dest_dir, contains_phi, spec)
         for scan in self.scans.values():
             for resource_name, resource in scan.resources.items():
                 resource_dest_dir = dest_dir / scan.id / resource_name
-                if not getattr(resource.fileset, "contains_phi", False):
-                    deid_resource = resource.fileset.copy(
-                        resource_dest_dir,
-                        mode=copy_mode,
-                        new_stem=resource_name,
-                        avoid_clashes=True,
-                    )
-                else:
+                contains_phi = getattr(resource.fileset, "contains_phi", False)
+                resource_spec = None
+                if contains_phi:
                     resource_spec = select_spec(resource.fileset)
                     if resource_spec is None:
                         msg = (
@@ -836,13 +913,41 @@ class ImagingSession:
                             raise KeyError(msg % msg_vars)
                         else:
                             logger.warning(msg, *msg_vars)
-                    deid_resource, reid_mdata = resource.fileset.deidentify(
-                        out_dir=resource_dest_dir, spec=resource_spec
+                tasks.append(
+                    (
+                        scan.id,
+                        scan.type,
+                        resource_name,
+                        resource.fileset,
+                        resource_dest_dir,
+                        contains_phi,
+                        resource_spec,
                     )
+                )
+
+        reid_series = []
+        with ProcessPoolExecutor(max_workers=resource_workers) as executor:
+            futures = {
+                executor.submit(
+                    _deidentify_or_copy_resource,
+                    fileset,
+                    resource_name,
+                    resource_dest_dir,
+                    contains_phi,
+                    resource_spec,
+                    copy_mode,
+                    file_workers,
+                ): (scan_id, scan_type, resource_name)
+                for scan_id, scan_type, resource_name, fileset, resource_dest_dir, contains_phi, resource_spec in tasks
+            }
+            for future in as_completed(futures):
+                scan_id, scan_type, resource_name = futures[future]
+                deid_resource, reid_mdata = future.result()
+                if reid_mdata is not None:
                     reid_series.append(reid_mdata)
                 deidentified.add_resource(
-                    scan.id,
-                    scan.type,
+                    scan_id,
+                    scan_type,
                     resource_name,
                     deid_resource,
                     avoid_clashes=avoid_clashes,

--- a/xnat_ingest/model/tests/test_session.py
+++ b/xnat_ingest/model/tests/test_session.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 import typing as ty
 from pathlib import Path
@@ -675,22 +676,37 @@ def test_assign_unresolvable_field_uses_placeholder_instead_of_raising(
 DEIDENTIFY_REID_MDATA = {"PatientName": "John Doe", "DOB": "19800101"}
 
 
+def _deidentify_test_impl(
+    fileset: File,
+    spec: ty.Any = None,
+    out_dir: ty.Optional[Path] = None,
+    **kwargs: ty.Any,
+) -> File:
+    dest = Path(out_dir)
+    dest.mkdir(parents=True, exist_ok=True)
+    deidentified = fileset.copy(dest)
+    # session.deidentify() now reconstructs reid metadata itself by diffing
+    # `metadata` before/after calling deidentify(), so the stand-in "stripped"
+    # fileset needs to actually report different metadata to the original.
+    deidentified._explicit_metadata = {}
+    return deidentified
+
+
 def _make_deid_fileset(seed: int, expected_reid: dict) -> File:
     """Return a File instance with contains_phi=True and an injected deidentify().
 
     Setting contains_phi=True routes it through the deidentify branch in
-    session.deidentify().  The injected method is called as an unbound function
-    (instance attribute), so it receives no implicit ``self``.
+    session.deidentify(). expected_reid is set as the fileset's explicit metadata so
+    that session.deidentify()'s before/after diff reconstructs it. The injected
+    method is a functools.partial binding a module-level function (not a closure), so
+    the fileset instance stays picklable -- session.deidentify() now dispatches
+    resources to a ProcessPoolExecutor, which requires everything submitted to it,
+    including any injected attributes on the fileset, to be picklable.
     """
     f = File.sample(seed=seed)
     f.contains_phi = True
-
-    def _deidentify(spec: ty.Any = None, out_dir: ty.Optional[Path] = None) -> tuple:
-        dest = Path(out_dir)
-        dest.mkdir(parents=True, exist_ok=True)
-        return f.copy(dest), dict(expected_reid)
-
-    f.deidentify = _deidentify
+    f._explicit_metadata = dict(expected_reid)
+    f.deidentify = functools.partial(_deidentify_test_impl, f)
     return f
 
 


### PR DESCRIPTION
…turn value

FileSet.deidentify() implementations across fileformats-medimage, fileformats-biosig and the vendor extras packages no longer return a (fileset, reid_metadata) tuple -- they just return the deidentified fileset. _deidentify_or_copy_resource() now snapshots metadata before calling deidentify() and diffs it against the result to build reid_mdata itself.

Also parallelises resources within a session deidentify across a ProcessPoolExecutor (resource_workers), with an additional file_workers knob passed through to formats whose own deidentify implementation can parallelise within a single resource (e.g. DicomCollection).